### PR TITLE
Remove 'zero_end = 1;' from btrfs_prepare_device()

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -594,7 +594,6 @@ int btrfs_prepare_device(int fd, char *file, int zero_end, u64 *block_count_ret,
 	}
 	if (max_block_count)
 		block_count = min(block_count, max_block_count);
-	zero_end = 1;
 
 	if (block_count < 1024 * 1024 * 1024 && !(*mixed)) {
 		printf("SMALL VOLUME: forcing mixed metadata/data groups\n");


### PR DESCRIPTION
In btrfs_prepare_device() function, zero_end is passed as a parameter,
then use it deal with zero_dev_end(), it should not be set to 1 in
btrfs_prepare_device().

Signed-off-by: Li Yang liyang.fnst@cn.fujitsu.com
