### PR TITLE
btrfs-convert: optout build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,11 @@ endif
 MAKEOPTS = --no-print-directory Q=$(Q)
 
 progs = mkfs.btrfs btrfs-debug-tree btrfsck \
-	btrfs btrfs-map-logical btrfs-image btrfs-zero-log btrfs-convert \
+	btrfs btrfs-map-logical btrfs-image btrfs-zero-log \
 	btrfs-find-root btrfstune btrfs-show-super
+ifneq ($(DISABLE_BTRFSCONVERT),1)
+progs += btrfs-convert
+endif
 
 progs_extra = btrfs-corrupt-block btrfs-fragments btrfs-calc-size \
 	      btrfs-select-super


### PR DESCRIPTION
btrfs-convert has dependencies which won't be met in every circumstance.
This patch introduces a new make switch for it:
	DISABLE_BTRFSCONVERT=1 make

This patch is just to get the idea. There are still some targets missing.
I needed this option because I didn't need to convert and didn't have the dependencies at hand.

Suggestions/Merging welcome.