### PR TITLE
btrfs-progs: fix unknown type name 'u64' in gccgo

### DIFF
--- a/ioctl.h
+++ b/ioctl.h
@@ -94,7 +94,7 @@ struct btrfs_ioctl_vol_args_v2 {
 	};
 	union {
 		char name[BTRFS_SUBVOL_NAME_MAX + 1];
-		u64 devid;
+		__u64 devid;
 	};
 };
 


### PR DESCRIPTION
Signed-off-by: Julio Montes <imc.coder@gmail.com>