### PR TITLE
Fix ASSERT() logic when backtrace is disabled

### DIFF
--- a/kerncompat.h
+++ b/kerncompat.h
@@ -299,7 +299,7 @@ static inline void assert_trace(const char *assertion, const char *filename,
 #else
 #define BUG_ON(c) assert(!(c))
 #define WARN_ON(c) warning_trace(#c, __FILE__, __func__, __LINE__, (long)(c))
-#define ASSERT(c) assert(!(c))
+#define ASSERT(c) assert((c))
 #define BUG() assert(0)
 #endif
 


### PR DESCRIPTION
dd2c2a4c67d509d90142b9443aa7449ef4257b2b apparently flipped the logic
of ASSERT() for the BTRFS_DISABLE_BACKTRACE case which results in bogus
assertion failures if configured with --disable-backtrace.