### PR TITLE
docs: fix typo in btrfs-scrub manual page

### DIFF
--- a/Documentation/btrfs-scrub.asciidoc
+++ b/Documentation/btrfs-scrub.asciidoc
@@ -28,7 +28,7 @@ The scrubbing status is recorded in '/var/lib/btrfs/' in textual files named
 'scrub.status.UUID' for a filesystem identified by the given UUID. (An
 itermediate progress is communicated through a named pipe in file
 'scrub.progress.UUID' in the same directory.) The status file is updated
-periodically every 5 seconds. An resumed scrub will continue from the last
+periodically every 5 seconds. A resumed scrub will continue from the last
 saved position.
 
 SUBCOMMAND


### PR DESCRIPTION
Changed "An" to "A".

Signed-off-by: Erik Logtenberg <erik@logtenberg.eu>