### PR TITLE
btrfs-progs: add missing limits headers

### DIFF
--- a/convert/source-ext2.c
+++ b/convert/source-ext2.c
@@ -16,6 +16,7 @@
 
 #if BTRFSCONVERT_EXT2
 
+#include <linux/limits.h>
 #include "kerncompat.h"
 #include "disk-io.h"
 #include "transaction.h"

--- a/mkfs/common.c
+++ b/mkfs/common.c
@@ -18,6 +18,7 @@
 #include <uuid/uuid.h>
 #include <blkid/blkid.h>
 #include <fcntl.h>
+#include <limits.h>
 #include "ctree.h"
 #include "disk-io.h"
 #include "volumes.h"


### PR DESCRIPTION
Build under musl libc fails because of missing PATH_MAX and XATTR_NAME_MAX
macro declarations. Add the required headers.

Signed-off-by: Baruch Siach <baruch@tkos.co.il>