### PR TITLE
Expand confusing abbreviation in documentation

### DIFF
--- a/Documentation/btrfs-balance.asciidoc
+++ b/Documentation/btrfs-balance.asciidoc
@@ -143,7 +143,7 @@ The minimum range boundary is inclusive, maximum is exclusive.
 
 *devid=<id>*::
 Balances only block groups which have at least one chunk on the given
-device. To list devices with ids use *btrfs fi show*.
+device. To list devices with ids use *btrfs filesystem show*.
 
 *drange=<range>*::
 Balance only block groups which overlap with the given byte range on any


### PR DESCRIPTION
While the command interpreter may be able to disambiguate
the meaning, the reader is not helped by being forced to do so.