### PR TITLE
btrfs-progs: docs: replace <dev> with <device>

### DIFF
--- a/Documentation/btrfs-device.asciidoc
+++ b/Documentation/btrfs-device.asciidoc
@@ -43,7 +43,7 @@ See the section *TYPICAL USECASES* for some examples.
 
 SUBCOMMAND
 ----------
-*add* [-Kf] <dev> [<dev>...] <path>::
+*add* [-Kf] <device> [<device>...] <path>::
 Add device(s) to the filesystem identified by <path>.
 +
 If applicable, a whole device discard (TRIM) operation is performed prior to
@@ -62,7 +62,7 @@ do not perform discard (TRIM) by default
 -f|--force::::
 force overwrite of existing filesystem on the given disk(s)
 
-*remove* <dev>|<devid> [<dev>|<devid>...] <path>::
+*remove* <device>|<devid> [<device>|<devid>...] <path>::
 Remove device(s) from a filesystem identified by <path>
 +
 Device removal must satisfy the profile constraints, otherwise the command
@@ -76,7 +76,7 @@ It is possible to delete the device that was used to mount the filesystem. The
 device entry in mount table will be replaced by another device name with the
 lowest device id.
 
-*delete* <dev>|<devid> [<dev>|<devid>...] <path>::
+*delete* <device>|<devid> [<device>|<devid>...] <path>::
 Alias of remove kept for backward compatibility
 
 *ready* <device>::

--- a/Documentation/btrfs-filesystem.asciidoc
+++ b/Documentation/btrfs-filesystem.asciidoc
@@ -170,7 +170,7 @@ show sizes in GiB, or GB with --si.
 --tbytes::::
 show sizes in TiB, or TB with --si.
 
-*label* [<dev>|<mountpoint>] [<newlabel>]::
+*label* [<device>|<mountpoint>] [<newlabel>]::
 Show or update the label of a filesystem. This works on a mounted filesystem or
 a filesystem image.
 +

--- a/Documentation/btrfs-find-root.asciidoc
+++ b/Documentation/btrfs-find-root.asciidoc
@@ -7,7 +7,7 @@ btrfs-find-root - filter to find btrfs root
 
 SYNOPSIS
 --------
-*btrfs-find-root* [options] <dev>
+*btrfs-find-root* [options] <device>
 
 DESCRIPTION
 -----------

--- a/Documentation/btrfstune.asciidoc
+++ b/Documentation/btrfstune.asciidoc
@@ -7,7 +7,7 @@ btrfstune - tune various filesystem parameters
 
 SYNOPSIS
 --------
-*btrfstune* [options] <dev> [<dev>...]
+*btrfstune* [options] <device> [<device>...]
 
 DESCRIPTION
 -----------


### PR DESCRIPTION
as discussed in #50

I believe this replaces all instances of \<dev>. Please confirm.