### PR TITLE
btrfs-progs: defrag: add a brief warning about ref-link breakage

### DIFF
--- a/cmds-filesystem.c
+++ b/cmds-filesystem.c
@@ -893,6 +893,11 @@ static const char * const cmd_filesystem_defrag_usage[] = {
 	"-s start            defragment only from byte onward",
 	"-l len              defragment only up to len bytes",
 	"-t size             target extent size hint (default: 32M)",
+	"",
+	"Warning: most Linux kernels will break up the ref-links of COW data",
+	"(e.g., files copied with 'cp --reflink', snapshots) which may cause",
+	"considerable increase of space usage. See btrfs-filesystem(8) for",
+	"more information.",
 	NULL
 };
 


### PR DESCRIPTION
```text
There is a warning in btrfs-filesystem(8) saying that running 'defrag'
in Linux will almost certainly break ref-links, with much data potentially
being physically duplicated.

However, many users tend to read man pages *after* trying to run things
on their own risk and may miss this important information. This commit
adds a brief copy of this warning into the command built-in help message
where it has good chances to be spotted before user is stuck with
a crowded filesystem.

(Signed-off-by)
```

If think it's a documentation-only change, so I decided to skip the mailing list routine. I'm new to Btrfs; in case I misunderstood something, feel free to reject the PR.
BTW, could someone please answer https://unix.stackexchange.com/questions/400225?