### PR TITLE
Update btrfs-subvolume.asciidoc

### DIFF
--- a/Documentation/btrfs-subvolume.asciidoc
+++ b/Documentation/btrfs-subvolume.asciidoc
@@ -154,7 +154,7 @@ The id can be obtained from *btrfs subvolume list*, *btrfs subvolume show* or
 Show information of a given subvolume in the <path>.
 
 *snapshot* [-r] <source> <dest>|[<dest>/]<name>::
-Create a writable/readonly snapshot of the subvolume <source> with the
+Create a snapshot of the subvolume <source> with the
 name <name> in the <dest> directory.
 +
 If only <dest> is given, the subvolume will be named the basename of <source>.

--- a/Documentation/btrfs-subvolume.asciidoc
+++ b/Documentation/btrfs-subvolume.asciidoc
@@ -159,7 +159,9 @@ name <name> in the <dest> directory.
 +
 If only <dest> is given, the subvolume will be named the basename of <source>.
 If <source> is not a subvolume, btrfs returns an error.
-If '-r' is given, the snapshot will be readonly.
++
+-r::::
+Make the new snapshot read only.
 
 *sync* <path> [subvolid...]::
 Wait until given subvolume(s) are completely removed from the filesystem


### PR DESCRIPTION
To simplify, I suggest moving the 'writable/readonly' issue only to the -r line, instead of having it introduced in two places.