### PR TITLE
btrfs-progs: prevent incorrect use of subvol_strip_mountpoint

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -2484,6 +2484,12 @@ const char *subvol_strip_mountpoint(const char *mnt, const char *full_path)
 	if (!len)
 		return full_path;
 
+	if ((strncmp(mnt, full_path, len) != 0) ||
+            (full_path[len] != '/')) {
+		error("not on mount point: %s", mnt);
+                exit(1);
+        }
+
 	if (mnt[len - 1] != '/')
 		len += 1;
 


### PR DESCRIPTION
Add additional bound checks to prevent memory corruption on incorrect
usage of subvol_strip_mountpoint. Assert sane return value by properly
comparing the mount point to the full_path before stripping it off.

Mitigates issue: "btrfs send -p" fails if source and parent subvolumes
are on different mountpoints (memory corruption):

    https://github.com/kdave/btrfs-progs/issues/96

Note that this does not properly fix this bug, but prevents a possible
security issue by unexpected usage of "btrfs send -p".

Signed-off-by: Axel Burri <axel@tty0.ch>