### PR TITLE
Fixed https://bugzilla.kernel.org/show_bug.cgi?id=199071

### DIFF
--- a/convert/source-ext2.c
+++ b/convert/source-ext2.c
@@ -422,7 +422,7 @@ static int ext2_xattr_check_entry(struct ext2_ext_attr_entry *entry,
 {
 	size_t value_size = entry->e_value_size;
 
-	if (entry->e_value_block != 0 || value_size > size ||
+	if (entry->e_value_inum != 0 || value_size > size ||
 	    entry->e_value_offs + value_size > size)
 		return -EIO;
 	return 0;


### PR DESCRIPTION
The change will fix 199071 and  now After this commit:
https://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git/commit/?id=6a081f6d2a5cff0f5a077065aab39901d54bfb61

we will have e->e_value_inum  not e->e_value_block for newer  e2fsprogs so this fix will make it compatible with e2fsprogs and resolve compile error