### PR TITLE
traverse_directory: Reset error code on continue.

### DIFF
--- a/mkfs/rootdir.c
+++ b/mkfs/rootdir.c
@@ -553,6 +553,7 @@ static int traverse_directory(struct btrfs_trans_handle *trans,
 						(unsigned long)st.st_nlink);
 					goto fail;
 				}
+				ret = 0;
 				continue;
 			}
 			if (ret) {


### PR DESCRIPTION
In case add_inode_items returned -EEXIST, traverse_directory would
handle the condition and still continue under certain circumstances, but
it would not reset the error code, leading to spurious failure later.
This patch fixes that.