### PR TITLE
btrfs-progs: fix regression preventing send -p with subvolumes mounted on "/"

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -2460,7 +2460,7 @@ const char *subvol_strip_mountpoint(const char *mnt, const char *full_path)
 	if (!len)
 		return full_path;
 
-	if ((strncmp(mnt, full_path, len) != 0) || (full_path[len] != '/')) {
+	if ((strncmp(mnt, full_path, len) != 0) || ((len > 1) && (full_path[len] != '/'))) {
 		error("not on mount point: %s", mnt);
 		exit(1);
 	}


### PR DESCRIPTION
Fix subvol_strip_mountpoint for mnt="/" (len=1). In this case, skip
check for trailing slash on full_path (leading slash on full_path is
already asserted by strncmp).

Fixes: c5dc299aff6b ("btrfs-progs: prevent incorrect use of subvol_strip_mountpoint")
Signed-off-by: Axel Burri <axel@tty0.ch>