### PR TITLE
btrfs-progs: docs: update remaining non-zero dev stats -s option to -c

### DIFF
--- a/Documentation/btrfs-device.asciidoc
+++ b/Documentation/btrfs-device.asciidoc
@@ -264,7 +264,7 @@ EXIT STATUS
 *btrfs device* returns a zero exit status if it succeeds. Non zero is
 returned in case of failure.
 
-If the '-s' option is used, *btrfs device stats* will add 64 to the
+If the '-c' option is used, *btrfs device stats* will add 64 to the
 exit status if any of the error counters is non-zero.
 
 AVAILABILITY


### PR DESCRIPTION
Update the remaining erroneous entry of -s in the 'exit status' section to -c in accordance with the changes made in:

"btrfs-progs: dev stats: update option name for checking non-zero status"

Signed-off-by: Philip Guyton <philip@yewtreeapps.com>