### PR TITLE
Spelling

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,7 +22,7 @@ btrfs-progs-4.17.1 (2018-08-06)
     * beautify progress output
   * btrfstune: allow to continue uuid change after unclean interruption
   * several fuzz fixes:
-    * detect overalpping chunks
+    * detect overlapping chunks
     * chunk loading error handling
     * don't crash with unexpected root refs to extents
   * relax option parsing again to allow mixing options and non-options

--- a/CHANGES
+++ b/CHANGES
@@ -244,7 +244,7 @@ btrfs-progs-4.11 (2017-05-18)
 btrfs-progs-4.10.2 (2017-03-31)
   * check: lowmem mode fix for false alert about lost backrefs
   * convert: minor bugfix
-  * library: fix build, misisng symbols, added tests
+  * library: fix build, missing symbols, added tests
 
 btrfs-progs-4.10.1 (2017-03-17)
   * receive: handle subvolume in path clone

--- a/CHANGES
+++ b/CHANGES
@@ -630,7 +630,7 @@ btrfs-progs-4.3 (2015-11-06)
     * test for broken 'subvolume sync'
     * basic tests for mkfs, raid option combinations
     * basic tests for fuzzed images (check)
-    * command intrumentation (eg valgrind)
+    * command instrumentation (eg valgrind)
     * print commands if requested
     * add README for tests
 

--- a/CHANGES
+++ b/CHANGES
@@ -355,7 +355,7 @@ btrfs-progs-4.8.3 (2016-11-11)
 
 btrfs-progs-4.8.2 (2016-10-26)
   * convert: also convert file attributes
-  * convert: fix wrong tree block alignment for unalianged block group
+  * convert: fix wrong tree block alignment for unaligned block group
   * check: quota verify fixes, handle reloc tree
   * build: add stub for FIEMAP_EXTENT_SHARED, compiles on ancient kernels
   * build: add stub for BUILD_ASSERT when ioctl.h is included

--- a/Documentation/DocConventions
+++ b/Documentation/DocConventions
@@ -34,6 +34,6 @@ Quotation in subcommands:
   - optional parameter with argument: [-p <path>]
 
 
-Refrences:
+References:
 - full asciidoc syntax: http://asciidoc.org/userguide.html
 - cheatsheet: http://powerman.name/doc/asciidoc

--- a/Documentation/DocConventions
+++ b/Documentation/DocConventions
@@ -23,7 +23,7 @@ Quotation in subcommands:
 - command reference: bold *btrfs fi show*
 - section references: italics 'EXAMPLES'
 
-- argument name in option desciption: caps in angle brackets <NAME>
+- argument name in option description: caps in angle brackets <NAME>
   - reference in help text: caps NAME
     also possible: caps italics 'NAME'
 

--- a/Documentation/btrfs-man5.asciidoc
+++ b/Documentation/btrfs-man5.asciidoc
@@ -156,7 +156,7 @@ under 'nodatacow' are also set the NOCOW file attribute (see `chattr`(1)).
 NOTE: If 'nodatacow' or 'nodatasum' are enabled, compression is disabled.
 +
 Updates in-place improve performance for workloads that do frequent overwrites,
-at the cost of potential partial writes, in case the write is interruted
+at the cost of potential partial writes, in case the write is interrupted
 (system crash, device failure).
 
 *datasum*::

--- a/Documentation/btrfs-man5.asciidoc
+++ b/Documentation/btrfs-man5.asciidoc
@@ -185,7 +185,7 @@ missing, for example if a stripe member is completely missing from RAID0.
 Since 4.14, the constraint checks have been improved and are verified on the
 chunk level, not an the device level. This allows degraded mounts of
 filesystems with mixed RAID profiles for data and metadata, even if the
-device number constraints would not be satisfied for some of the prifles.
+device number constraints would not be satisfied for some of the profiles.
 +
 Example: metadata -- raid1, data -- single, devices -- /dev/sda, /dev/sdb
 +

--- a/Documentation/btrfs-man5.asciidoc
+++ b/Documentation/btrfs-man5.asciidoc
@@ -171,7 +171,7 @@ corresponding file attribute (see `chattr`(1)).
 NOTE: If 'nodatacow' or 'nodatasum' are enabled, compression is disabled.
 +
 There is a slight performance gain when checksums are turned off, the
-correspoinding metadata blocks holding the checksums do not need to updated.
+corresponding metadata blocks holding the checksums do not need to updated.
 The cost of checksumming of the blocks in memory is much lower than the IO,
 modern CPUs feature hardware support of the checksumming algorithm.
 

--- a/Documentation/btrfs-qgroup.asciidoc
+++ b/Documentation/btrfs-qgroup.asciidoc
@@ -52,7 +52,7 @@ assignment would lead to quota inconsistency. See 'QUOTA RESCAN' for more
 information.
 --no-rescan::::
 Explicitly ask not to do a rescan, even if the assignment will make the quotas
-inconsitent. This may be useful for repeated calls where the rescan would add
+inconsistent. This may be useful for repeated calls where the rescan would add
 unnecessary overhead.
 
 *create* <qgroupid> <path>::

--- a/Makefile
+++ b/Makefile
@@ -631,7 +631,7 @@ clean-doc:
 
 clean-gen:
 	@echo "Cleaning Generated Files"
-	$(Q)$(RM) -rf -- version.h config.status config.cache connfig.log \
+	$(Q)$(RM) -rf -- version.h config.status config.cache config.log \
 		configure.lineno config.status.lineno Makefile.inc \
 		Documentation/Makefile tags \
 		cscope.files cscope.out cscope.in.out cscope.po.out \

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Documentation updates
 ---------------------
 
 Documentation fixes or updates do not need much explanation so sticking to the
-code rules in the previous section is not necessary. Github pull requests are
+code rules in the previous section is not necessary. GitHub pull requests are
 OK, patches could be sent to me directly and not required to be also in the
 mailinglist. Pointing out typos via IRC also works, although might get
 accidentally lost in the noise.

--- a/btrfs-list.h
+++ b/btrfs-list.h
@@ -168,7 +168,7 @@ struct btrfs_list_comparer_set *btrfs_list_alloc_comparer_set(void);
 
 int btrfs_list_subvols_print(int fd, struct btrfs_list_filter_set *filter_set,
 		       struct btrfs_list_comparer_set *comp_set,
-		       enum btrfs_list_layout layot, int full_path,
+		       enum btrfs_list_layout layout, int full_path,
 		       const char *raw_prefix);
 int btrfs_list_find_updated_files(int fd, u64 root_id, u64 oldest_gen);
 int btrfs_list_get_default_subvolume(int fd, u64 *default_id);

--- a/btrfs-select-super.c
+++ b/btrfs-select-super.c
@@ -34,7 +34,7 @@
 static void print_usage(void)
 {
 	printf("usage: btrfs-select-super -s number dev\n");
-	printf("\t-s super   copy of superbloc to overwrite the primary one (values: 1, 2)\n");
+	printf("\t-s super   copy of superblock to overwrite the primary one (values: 1, 2)\n");
 	exit(1);
 }
 

--- a/btrfs.c
+++ b/btrfs.c
@@ -169,7 +169,7 @@ static int cmd_version(int argc, char **argv)
  * Parse global options, between binary name and first non-option argument
  * after processing all valid options (including those with arguments).
  *
- * Returns index to argv where parsting stopped, optind is reset to 1
+ * Returns index to argv where parsing stopped, optind is reset to 1
  */
 static int handle_global_options(int argc, char **argv)
 {

--- a/btrfsck.h
+++ b/btrfsck.h
@@ -113,7 +113,7 @@ struct device_extent_record {
 	u8  type;
 	u64 offset;
 
-	u64 chunk_objecteid;
+	u64 chunk_objectid;
 	u64 chunk_offset;
 	u64 length;
 };

--- a/check/main.c
+++ b/check/main.c
@@ -9146,7 +9146,7 @@ static int build_roots_info_cache(struct btrfs_fs_info *info)
 		 * It's a valid extent/metadata item that has no inline ref,
 		 * but SHARED_BLOCK_REF or other shared references.
 		 * So we need to do extra check to avoid reading beyond leaf
-		 * boudnary.
+		 * boundary.
 		 */
 		if ((unsigned long)iref >= item_end)
 			goto next;

--- a/check/main.c
+++ b/check/main.c
@@ -4052,7 +4052,7 @@ static int try_to_fix_bad_block(struct btrfs_root *root,
 	btrfs_init_path(&path);
 	ULIST_ITER_INIT(&iter);
 	/*
-	 * If we found no roots referrening to this tree block, there is no
+	 * If we found no roots referencing to this tree block, there is no
 	 * chance to fix. So our default ret is -EIO.
 	 */
 	ret = -EIO;

--- a/check/main.c
+++ b/check/main.c
@@ -8654,7 +8654,7 @@ static int reinit_extent_tree(struct btrfs_trans_handle *trans,
 	 * first we need to walk all of the trees except the extent tree and pin
 	 * down/exclude the bytes that are in use so we don't overwrite any
 	 * existing metadata.
-	 * If pinnned, unpin will be done in the end of transaction.
+	 * If pinned, unpin will be done in the end of transaction.
 	 * If excluded, cleanup will be done in check_chunks_and_extents_lowmem.
 	 */
 again:

--- a/check/main.c
+++ b/check/main.c
@@ -7851,7 +7851,7 @@ static int check_chunk_refs(struct chunk_record *chunk_rec,
 			    dev_extent_rec->length != length) {
 				if (!silent)
 					fprintf(stderr,
-						"Chunk[%llu, %u, %llu] stripe[%llu, %llu] dismatch dev extent[%llu, %llu, %llu]\n",
+						"Chunk[%llu, %u, %llu] stripe[%llu, %llu] mismatch dev extent[%llu, %llu, %llu]\n",
 						chunk_rec->objectid,
 						chunk_rec->type,
 						chunk_rec->offset,

--- a/check/main.c
+++ b/check/main.c
@@ -5043,7 +5043,7 @@ btrfs_new_device_extent_record(struct extent_buffer *leaf,
 	rec->offset = key->offset;
 
 	ptr = btrfs_item_ptr(leaf, slot, struct btrfs_dev_extent);
-	rec->chunk_objecteid =
+	rec->chunk_objectid =
 		btrfs_dev_extent_chunk_objectid(leaf, ptr);
 	rec->chunk_offset =
 		btrfs_dev_extent_chunk_offset(leaf, ptr);

--- a/check/main.c
+++ b/check/main.c
@@ -6871,7 +6871,7 @@ static int verify_backrefs(struct btrfs_fs_info *info, struct btrfs_path *path,
 		goto out;
 
 	fprintf(stderr,
-		"attempting to repair backref discrepency for bytenr %llu\n",
+		"attempting to repair backref discrepancy for bytenr %llu\n",
 		rec->start);
 
 	/*

--- a/check/main.c
+++ b/check/main.c
@@ -9484,7 +9484,7 @@ const char * const cmd_check_usage[] = {
 	"trees' consistency and item connectivity. In the repair mode try to",
 	"fix the problems found. ",
 	"WARNING: the repair mode is considered dangerous and should not be used",
-	"         without prior analysis of problems found on the flesystem."
+	"         without prior analysis of problems found on the filesystem."
 	"",
 	"Options:",
 	"  starting point selection:",

--- a/check/mode-common.c
+++ b/check/mode-common.c
@@ -493,7 +493,7 @@ out:
 }
 
 /*
- * Extra (optional) check for dev_item size to report possbile problem on a new
+ * Extra (optional) check for dev_item size to report possible problem on a new
  * kernel.
  */
 void check_dev_size_alignment(u64 devid, u64 total_bytes, u32 sectorsize)

--- a/check/mode-lowmem.c
+++ b/check/mode-lowmem.c
@@ -2636,7 +2636,7 @@ again:
 	if (err & LAST_ITEM)
 		goto out;
 
-	/* still have inode items in thie leaf */
+	/* still have inode items in this leaf */
 	if (cur->start == cur_bytenr)
 		goto again;
 

--- a/check/mode-lowmem.c
+++ b/check/mode-lowmem.c
@@ -2674,7 +2674,7 @@ out:
 
 /*
  * @level           if @level == -1 means extent data item
- *                  else normal treeblocl.
+ *                  else normal treeblock.
  */
 static int should_check_extent_strictly(struct btrfs_root *root,
 					struct node_refs *nrefs, int level)

--- a/check/mode-lowmem.h
+++ b/check/mode-lowmem.h
@@ -56,7 +56,7 @@
 #define BACKREF_MISMATCH	(1 << 1) /* Backref exists but does not match */
 #define BYTES_UNALIGNED		(1 << 2) /* Some bytes are not aligned */
 #define REFERENCER_MISSING	(1 << 3) /* Referencer not found */
-#define REFERENCER_MISMATCH	(1 << 4) /* Referenceer found but does not match */
+#define REFERENCER_MISMATCH	(1 << 4) /* Referencer found but does not match */
 #define CROSSING_STRIPE_BOUNDARY (1 << 4) /* For kernel scrub workaround */
 #define ITEM_SIZE_MISMATCH	(1 << 5) /* Bad item size */
 #define UNKNOWN_TYPE		(1 << 6) /* Unknown type */

--- a/cmds-rescue.c
+++ b/cmds-rescue.c
@@ -111,7 +111,7 @@ static const char * const cmd_rescue_super_recover_usage[] = {
  *   0 : All superblocks are valid, no need to recover
  *   1 : Usage or syntax error
  *   2 : Recover all bad superblocks successfully
- *   3 : Fail to Recover bad supeblocks
+ *   3 : Fail to Recover bad superblocks
  *   4 : Abort to recover bad superblocks
  */
 static int cmd_rescue_super_recover(int argc, char **argv)

--- a/configure.ac
+++ b/configure.ac
@@ -85,7 +85,7 @@ fi
 
 
 AC_ARG_ENABLE([documentation],
-	      AS_HELP_STRING([--disable-documentation], [do not build domumentation]),
+	      AS_HELP_STRING([--disable-documentation], [do not build documentation]),
   [], [enable_documentation=yes]
 )
 AS_IF([test "x$enable_documentation" = xyes], [DISABLE_DOCUMENTATION=0], [DISABLE_DOCUMENTATION=1])

--- a/convert/common.c
+++ b/convert/common.c
@@ -76,7 +76,7 @@ static inline int write_temp_super(int fd, struct btrfs_super_block *sb,
 }
 
 /*
- * Setup temporary superblock at cfg->super_bynter
+ * Setup temporary superblock at cfg->super_bytenr
  * Needed info are extracted from cfg, and root_bytenr, chunk_bytenr
  *
  * For now sys chunk array will be empty and dev_item is empty too.

--- a/convert/common.c
+++ b/convert/common.c
@@ -98,7 +98,7 @@ static int setup_temp_super(int fd, struct btrfs_mkfs_config *cfg,
 
 	if (*cfg->fs_uuid) {
 		if (uuid_parse(cfg->fs_uuid, super->fsid) != 0) {
-			error("cound not parse UUID: %s", cfg->fs_uuid);
+			error("could not parse UUID: %s", cfg->fs_uuid);
 			ret = -EINVAL;
 			goto out;
 		}

--- a/convert/main.c
+++ b/convert/main.c
@@ -682,7 +682,7 @@ static int calculate_available_space(struct btrfs_convert_context *cctx)
 	cur_off = 0;
 	/*
 	 * Calculate free space
-	 * Always round up the start bytenr, to avoid metadata extent corss
+	 * Always round up the start bytenr, to avoid metadata extent cross
 	 * stripe boundary, as later mkfs_convert() won't have all the extent
 	 * allocation check
 	 */

--- a/convert/main.c
+++ b/convert/main.c
@@ -1356,7 +1356,7 @@ out:
  * Iterate all file extents of the convert image.
  *
  * All file extents except ones in btrfs_reserved_ranges must be mapped 1:1
- * on disk. (Means thier file_offset must match their on disk bytenr)
+ * on disk. (Means their file_offset must match their on disk bytenr)
  *
  * File extents in reserved ranges can be relocated to other place, and in
  * that case we will read them out for later use.

--- a/convert/main.c
+++ b/convert/main.c
@@ -1344,7 +1344,7 @@ static bool is_chunk_direct_mapped(struct btrfs_fs_info *fs_info, u64 start)
 	if (map->num_stripes != 1)
 		goto out;
 
-	/* Chunk's logical doesn't match with phisical, not 1:1 mapped */
+	/* Chunk's logical doesn't match with physical, not 1:1 mapped */
 	if (map->ce.start != map->stripes[0].physical)
 		goto out;
 	ret = true;

--- a/convert/main.c
+++ b/convert/main.c
@@ -724,7 +724,7 @@ out:
 
 /*
  * Read used space, and since we have the used space,
- * calcuate data_chunks and free for later mkfs
+ * calculate data_chunks and free for later mkfs
  */
 static int convert_read_used_space(struct btrfs_convert_context *cctx)
 {

--- a/convert/source-fs.h
+++ b/convert/source-fs.h
@@ -26,7 +26,7 @@
 #define CONV_IMAGE_SUBVOL_OBJECTID BTRFS_FIRST_FREE_OBJECTID
 
 /*
- * Reresents a simple contiguous range.
+ * Represents a simple contiguous range.
  *
  * For multiple or non-contiguous ranges, use extent_cache_tree from
  * extent-cache.c

--- a/convert/source-reiserfs.c
+++ b/convert/source-reiserfs.c
@@ -564,7 +564,7 @@ static int reiserfs_copy_meta(reiserfs_filsys_t fs, struct btrfs_root *root,
 	};
 
 	/* The root directory's dirid in reiserfs points to an object
-	 * that does't exist.  In btrfs it's self-referential.
+	 * that doens't exist.  In btrfs it's self-referential.
 	 */
 	if (deh_dirid == REISERFS_ROOT_PARENT_OBJECTID)
 		parent = objectid;

--- a/convert/source-reiserfs.c
+++ b/convert/source-reiserfs.c
@@ -301,7 +301,7 @@ static int reiserfs_record_indirect_extent(reiserfs_filsys_t fs, u64 position,
 
 /*
  * Unlike btrfs inline extents, reiserfs can have multiple inline extents.
- * This handles concatanating multiple tails into one inline extent
+ * This handles concatenating multiple tails into one inline extent
  * for insertion.
  */
 static int reiserfs_record_direct_extent(reiserfs_filsys_t fs, __u64 position,

--- a/ctree.c
+++ b/ctree.c
@@ -3043,7 +3043,7 @@ int btrfs_previous_item(struct btrfs_root *root,
 
 /*
  * search in extent tree to find a previous Metadata/Data extent item with
- * min objecitd.
+ * min objectid.
  *
  * returns 0 if something is found, 1 if nothing was found and < 0 on error
  */

--- a/ctree.h
+++ b/ctree.h
@@ -97,7 +97,7 @@ struct btrfs_free_space_ctl;
 /* for storing balance parameters in the root tree */
 #define BTRFS_BALANCE_OBJECTID -4ULL
 
-/* oprhan objectid for tracking unlinked/truncated files */
+/* orphan objectid for tracking unlinked/truncated files */
 #define BTRFS_ORPHAN_OBJECTID -5ULL
 
 /* does write ahead logging to speed up fsyncs */

--- a/ctree.h
+++ b/ctree.h
@@ -119,7 +119,7 @@ struct btrfs_free_space_ctl;
 #define BTRFS_FREE_SPACE_OBJECTID -11ULL
 
 /*
- * The inode number assigned to the special inode for sotring
+ * The inode number assigned to the special inode for storing
  * free ino cache
  */
 #define BTRFS_FREE_INO_OBJECTID -12ULL

--- a/ctree.h
+++ b/ctree.h
@@ -2404,7 +2404,7 @@ static inline struct btrfs_disk_balance_args* btrfs_balance_item_sys(
 
 /*
  * btrfs_dev_stats_item helper, returns pointer to the raw array, do the
- * endiannes conversion, @dsi is offset to eb data
+ * endianness conversion, @dsi is offset to eb data
  */
 static inline __le64* btrfs_dev_stats_values(struct extent_buffer *eb,
 		struct btrfs_dev_stats_item *dsi)

--- a/disk-io.c
+++ b/disk-io.c
@@ -1440,7 +1440,7 @@ error_out:
  * @sb_bytenr:  offset of the particular superblock copy we want
  * @sbflags:	flags controlling how the superblock is read
  *
- * This function is used by various btrfs comands to obtain a valid superblock.
+ * This function is used by various btrfs commands to obtain a valid superblock.
  *
  * It's mode of operation is controlled by the @sb_bytenr and @sbdflags
  * parameters. If SBREAD_RECOVER flag is set and @sb_bytenr is

--- a/disk-io.h
+++ b/disk-io.h
@@ -36,7 +36,7 @@ enum btrfs_open_ctree_flags {
 	OPEN_CTREE_PARTIAL		= (1U << 1),
 	/* If primary root pinters are invalid, try backup copies */
 	OPEN_CTREE_BACKUP_ROOT		= (1U << 2),
-	/* Allow reading all superblock sopies if the primary is damaged */
+	/* Allow reading all superblock copies if the primary is damaged */
 	OPEN_CTREE_RECOVER_SUPER	= (1U << 3),
 	/* Restoring filesystem image */
 	OPEN_CTREE_RESTORE		= (1U << 4),

--- a/file.c
+++ b/file.c
@@ -178,7 +178,7 @@ out:
  * 3) data read out is also aligned to sectorsize, not truncated to inode size
  *
  * Return < 0 for fatal error during read.
- * Otherwise return the number of succesfully read data in bytes.
+ * Otherwise return the number of successfully read data in bytes.
  */
 int btrfs_read_file(struct btrfs_root *root, u64 ino, u64 start, int len,
 		    char *dest)

--- a/file.c
+++ b/file.c
@@ -301,7 +301,7 @@ next:
 
 	/*
 	 * Special trick for no_holes, since for no_holes we don't have good
-	 * method to account skipped and tailling holes, we used
+	 * method to account skipped and tailing holes, we used
 	 * min(inode size, len) as return value
 	 */
 	if (no_holes) {

--- a/help.c
+++ b/help.c
@@ -108,7 +108,7 @@ void clean_args_no_options(int argc, char *argv[], const char * const *usagestr)
 
 /*
  * Same as clean_args_no_options but pass through arguments that could look
- * like short options. Eg. reisze which takes a negative resize argument like
+ * like short options. Eg. resize which takes a negative resize argument like
  * '-123M' .
  *
  * This accepts only two forms:

--- a/image/main.c
+++ b/image/main.c
@@ -2496,7 +2496,7 @@ int main(int argc, char *argv[])
 	} else {
 		if (walk_trees || sanitize != SANITIZE_NONE || compress_level) {
 			error(
-			"useing -w, -s, -c options for restore makes no sense");
+			"using -w, -s, -c options for restore makes no sense");
 			usage_error++;
 		}
 		if (multi_devices && dev_cnt < 2) {

--- a/kernel-lib/raid56.c
+++ b/kernel-lib/raid56.c
@@ -330,7 +330,7 @@ int raid56_recov(int nr_devs, size_t stripe_len, u64 profile, int dest1,
 			return 0;
 		}
 
-		/* Regerneate data from P */
+		/* Regenerate data from P */
 		return raid5_gen_result(nr_devs - 1, stripe_len, dest1, data);
 	}
 

--- a/kernel-lib/rbtree.h
+++ b/kernel-lib/rbtree.h
@@ -19,7 +19,7 @@
   linux/include/linux/rbtree.h
 
   To use rbtrees you'll have to implement your own insert and search cores.
-  This will avoid us to use callbacks and to drop drammatically performances.
+  This will avoid us to use callbacks and to drop dramatically performances.
   I know it's not the cleaner way,  but in C (not in C++) to get
   performances and genericity...
 

--- a/libbtrfsutil/README.md
+++ b/libbtrfsutil/README.md
@@ -32,7 +32,7 @@ A few guidelines:
 * Don't require the Btrfs UAPI headers for any interfaces (e.g., instead of
   directly exposing a type from `linux/btrfs_tree.h`, abstract it away in a
   type specific to `libbtrfsutil`)
-* Preserve API and ABI compatability at all times (i.e., we don't want to bump
+* Preserve API and ABI compatibility at all times (i.e., we don't want to bump
   the library major version if we don't have to)
 * Include Python bindings for all interfaces
 * Write tests for all interfaces

--- a/libbtrfsutil/btrfs.h
+++ b/libbtrfsutil/btrfs.h
@@ -134,7 +134,7 @@ struct btrfs_scrub_progress {
 	__u64 tree_bytes_scrubbed;	/* # of tree bytes scrubbed */
 	__u64 read_errors;		/* # of read errors encountered (EIO) */
 	__u64 csum_errors;		/* # of failed csum checks */
-	__u64 verify_errors;		/* # of occurences, where the metadata
+	__u64 verify_errors;		/* # of occurrences, where the metadata
 					 * of a tree block did not match the
 					 * expected values, like generation or
 					 * logical */
@@ -154,7 +154,7 @@ struct btrfs_scrub_progress {
 	__u64 last_physical;		/* last physical address scrubbed. In
 					 * case a scrub was aborted, this can
 					 * be used to restart the scrub */
-	__u64 unverified_errors;	/* # of occurences where a read for a
+	__u64 unverified_errors;	/* # of occurrences where a read for a
 					 * full (64k) bio failed, but the re-
 					 * check succeeded for each 4k piece.
 					 * Intermittent error. */

--- a/libbtrfsutil/btrfs_tree.h
+++ b/libbtrfsutil/btrfs_tree.h
@@ -54,7 +54,7 @@
 /* for storing balance parameters in the root tree */
 #define BTRFS_BALANCE_OBJECTID -4ULL
 
-/* orhpan objectid for tracking unlinked/truncated files */
+/* orphan objectid for tracking unlinked/truncated files */
 #define BTRFS_ORPHAN_OBJECTID -5ULL
 
 /* does write ahead logging to speed up fsyncs */

--- a/libbtrfsutil/btrfs_tree.h
+++ b/libbtrfsutil/btrfs_tree.h
@@ -270,7 +270,7 @@
 #define BTRFS_PERSISTENT_ITEM_KEY	249
 
 /*
- * Persistantly stores the device replace state in the device tree.
+ * Persistently stores the device replace state in the device tree.
  * The key is built like this: (0, BTRFS_DEV_REPLACE_KEY, 0).
  */
 #define BTRFS_DEV_REPLACE_KEY	250

--- a/mkfs/rootdir.c
+++ b/mkfs/rootdir.c
@@ -724,8 +724,8 @@ u64 btrfs_mkfs_size_dir(const char *dir_name, u32 sectorsize, u64 min_dev_size,
 	u64 meta_threshold = SZ_8M;
 	u64 data_threshold = SZ_8M;
 
-	float data_multipler = 1;
-	float meta_multipler = 1;
+	float data_multiplier = 1;
+	float meta_multiplier = 1;
 
 	fs_block_size = sectorsize;
 	ftw_data_size = 0;
@@ -763,11 +763,11 @@ u64 btrfs_mkfs_size_dir(const char *dir_name, u32 sectorsize, u64 min_dev_size,
 	/* Minimal chunk size from btrfs_alloc_chunk(). */
 	if (meta_profile & BTRFS_BLOCK_GROUP_DUP) {
 		meta_threshold = SZ_32M;
-		meta_multipler = 2;
+		meta_multiplier = 2;
 	}
 	if (data_profile & BTRFS_BLOCK_GROUP_DUP) {
 		data_threshold = SZ_64M;
-		data_multipler = 2;
+		data_multiplier = 2;
 	}
 
 	/*
@@ -777,10 +777,10 @@ u64 btrfs_mkfs_size_dir(const char *dir_name, u32 sectorsize, u64 min_dev_size,
 	 */
 	if (meta_size > meta_threshold)
 		meta_chunk_size = (round_up(meta_size, meta_threshold) -
-				   meta_threshold) * meta_multipler;
+				   meta_threshold) * meta_multiplier;
 	if (ftw_data_size > data_threshold)
 		data_chunk_size = (round_up(ftw_data_size, data_threshold) -
-				   data_threshold) * data_multipler;
+				   data_threshold) * data_multiplier;
 
 	total_size = data_chunk_size + meta_chunk_size + min_dev_size;
 	return total_size;

--- a/print-tree.c
+++ b/print-tree.c
@@ -887,7 +887,7 @@ static void print_uuid_item(struct extent_buffer *l, unsigned long offset,
 })
 
 /*
- * Caller should ensure sizeof(*ret) >= 102: all charactors plus '|' of
+ * Caller should ensure sizeof(*ret) >= 102: all characters plus '|' of
  * BTRFS_INODE_* flags
  */
 static void inode_flags_to_str(u64 flags, char *ret)

--- a/qgroup-verify.c
+++ b/qgroup-verify.c
@@ -1339,7 +1339,7 @@ int report_qgroups(int all)
 	if (counts.qgroup_inconsist && !counts.rescan_running &&
 	    counts.rescan_running == 0) {
 		printf(
-"Rescan hasn't been initialzied, a difference in qgroup accounting is expected\n");
+"Rescan hasn't been initialized, a difference in qgroup accounting is expected\n");
 		skip_err = true;
 	}
 	if (counts.qgroup_inconsist && !counts.rescan_running)

--- a/send-dump.c
+++ b/send-dump.c
@@ -47,7 +47,7 @@
 })
 
 /*
- * Print path and escape chaacters (in a C way) that could break the line.
+ * Print path and escape characters (in a C way) that could break the line.
  * Returns the length of the escaped characters. Unprintable characters are
  * escaped as octals.
  */

--- a/send-stream.c
+++ b/send-stream.c
@@ -35,7 +35,7 @@ struct btrfs_send_stream {
 
 	/*
 	 * end of last successful read, equivalent to start of current
-	 * malformated part of block
+	 * malformed part of block
 	 */
 	size_t stream_pos;
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -194,7 +194,7 @@ $ TEST=012\* ./misc-tests.sh           # from tests/
 
 Most tests should be able to create the test images from scratch, using regular
 commands and file operation. The commands also document the testcase and use
-the teste code and kernel of the environment.
+the test code and kernel of the environment.
 
 In other cases, a pre-created image may be the right way if the above does not
 work (eg. comparing output, requesting an exact layout or some intermediate

--- a/tests/cli-tests/007-check-force/test.sh
+++ b/tests/cli-tests/007-check-force/test.sh
@@ -10,7 +10,7 @@ check_prereq btrfs
 setup_root_helper
 
 # we need to use a real block device, because the check opens the device in
-# exclusive mode, that unfortunatelly behaves differently for direct file
+# exclusive mode, that unfortunately behaves differently for direct file
 # access and for the real /dev/loop0 device
 setup_loopdevs 1
 prepare_loopdevs

--- a/tests/fsck-tests/025-file-extents/test.sh
+++ b/tests/fsck-tests/025-file-extents/test.sh
@@ -15,7 +15,7 @@ prepare_test_dev 128M
 
 # Do some write into a large prealloc range
 # Lowmem mode can report missing csum due to wrong csum range
-test_paritical_write_into_prealloc()
+test_partial_write_into_prealloc()
 {
 	run_check $SUDO_HELPER "$TOP/mkfs.btrfs" -f "$TEST_DEV"
 	run_check_mount_test_dev
@@ -55,6 +55,6 @@ test_hole_extent_with_no_holes_flag()
 	run_check "$TOP/btrfs" check "$TEST_DEV"
 }
 
-test_paritical_write_into_prealloc
+test_partial_write_into_prealloc
 test_compressed_inline_extent
 test_hole_extent_with_no_holes_flag

--- a/tests/fsck-tests/031-metadatadump-check-data-csum/test.sh
+++ b/tests/fsck-tests/031-metadatadump-check-data-csum/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# To check if "btrfs check" can detect metadata dump (restored by btrfs-iamge)
+# To check if "btrfs check" can detect metadata dump (restored by btrfs-image)
 # and ignore --check-data-csum option
 
 source "$TEST_TOP/common"

--- a/tests/fsck-tests/031-metadatadump-check-data-csum/test.sh
+++ b/tests/fsck-tests/031-metadatadump-check-data-csum/test.sh
@@ -21,7 +21,7 @@ chmod a+w restored_image
 run_check $SUDO_HELPER "$TOP/btrfs-image" "$TEST_DEV" "restored_image"
 
 # use prepare_test_dev() to wipe all existing data on $TEST_DEV
-# so there is no way that restored image could have mathcing data csum
+# so there is no way that restored image could have matching data csum
 prepare_test_dev
 
 run_check $SUDO_HELPER "$TOP/btrfs-image" -r "restored_image" "$TEST_DEV"

--- a/tests/fsck-tests/036-rescan-not-kicked-in/test.sh
+++ b/tests/fsck-tests/036-rescan-not-kicked-in/test.sh
@@ -4,7 +4,7 @@
 # low probability.
 #
 # This test case verifies a special case when 'btrfs check' does not report
-# qgroup accounting differece as an error, thus no false alert for btrfs/166.
+# qgroup accounting difference as an error, thus no false alert for btrfs/166.
 
 source "$TEST_TOP/common"
 

--- a/tests/misc-tests/006-image-on-missing-device/test.sh
+++ b/tests/misc-tests/006-image-on-missing-device/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # test btrfs-image with a missing device (uses loop devices)
 #
-# - btrfs-image must not loop indefinetelly
+# - btrfs-image must not loop indefinitely
 # - btrfs-image will expectedly fail to produce the dump
 
 source "$TEST_TOP/common"

--- a/tests/misc-tests/029-send-p-different-mountpoints/test.sh
+++ b/tests/misc-tests/029-send-p-different-mountpoints/test.sh
@@ -10,7 +10,7 @@ check_prereq mkfs.btrfs
 setup_root_helper
 prepare_test_dev
 
-# we need two mount points, cannot nest the subvoolume under TEST_MNT
+# we need two mount points, cannot nest the subvolume under TEST_MNT
 SUBVOL_MNT="$TEST_MNT/subvol"
 TOPLEVEL_MNT="$TEST_MNT/toplevel"
 TEST_MNT="$TOPLEVEL_MNT"

--- a/transaction.c
+++ b/transaction.c
@@ -188,7 +188,7 @@ commit_tree:
 	ret = commit_tree_roots(trans, fs_info);
 	BUG_ON(ret);
 	/*
-	 * Ensure that all comitted roots are properly accounted in the
+	 * Ensure that all committed roots are properly accounted in the
 	 * extent tree
 	 */
 	ret = btrfs_run_delayed_refs(trans, -1);

--- a/utils.c
+++ b/utils.c
@@ -835,7 +835,7 @@ static int blk_file_in_dev_list(struct btrfs_fs_devices* fs_devices,
 /*
  * Resolve a pathname to a device mapper node to /dev/mapper/<name>
  * Returns NULL on invalid input or malloc failure; Other failures
- * will be handled by the caller using the input pathame.
+ * will be handled by the caller using the input pathname.
  */
 char *canonicalize_dm_name(const char *ptname)
 {
@@ -866,7 +866,7 @@ char *canonicalize_dm_name(const char *ptname)
  * Resolve a pathname to a canonical device node, e.g. /dev/sda1 or
  * to a device mapper pathname.
  * Returns NULL on invalid input or malloc failure; Other failures
- * will be handled by the caller using the input pathame.
+ * will be handled by the caller using the input pathname.
  */
 char *canonicalize_path(const char *path)
 {

--- a/utils.c
+++ b/utils.c
@@ -60,7 +60,7 @@
 
 static int btrfs_scan_done = 0;
 
-static int rand_seed_initlized = 0;
+static int rand_seed_initialized = 0;
 static unsigned short rand_seed[3];
 
 struct btrfs_config bconf;
@@ -2487,7 +2487,7 @@ void init_rand_seed(u64 seed)
 		rand_seed[i] = (unsigned short)(seed ^ (unsigned short)(-1));
 		seed >>= 16;
 	}
-	rand_seed_initlized = 1;
+	rand_seed_initialized = 1;
 }
 
 static void __init_seed(void)
@@ -2496,7 +2496,7 @@ static void __init_seed(void)
 	int ret;
 	int fd;
 
-	if(rand_seed_initlized)
+	if(rand_seed_initialized)
 		return;
 	/* Use urandom as primary seed source. */
 	fd = open("/dev/urandom", O_RDONLY);
@@ -2514,7 +2514,7 @@ fallback:
 		rand_seed[1] = getppid() ^ (tv.tv_usec & 0xFFFF);
 		rand_seed[2] = (tv.tv_sec ^ tv.tv_usec) >> 16;
 	}
-	rand_seed_initlized = 1;
+	rand_seed_initialized = 1;
 }
 
 u32 rand_u32(void)


### PR DESCRIPTION
Generated by https://github.com/jsoref/spelling `f`; to maintain your repo, please consider `fchurn`

Note: I understand that the commit message style doesn't quite match. I can squish/rewrite as requested.

There are a couple of commits where I'm guessing about the corrections...