### PR TITLE
Makefile: apply LDFLAGS to libbtrfsutil.so

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -424,7 +424,7 @@ libbtrfsutil/%.o: libbtrfsutil/%.c
 
 libbtrfsutil.so.$(libbtrfsutil_version): $(libbtrfsutil_objects)
 	@echo "    [LD]     $@"
-	$(Q)$(CC) $(LIBBTRFSUTIL_CFLAGS) $(libbtrfsutil_objects) \
+	$(Q)$(CC) $(LIBBTRFSUTIL_CFLAGS) $(libbtrfsutil_objects) $(LDFLAGS) \
 		-shared -Wl,-soname,libbtrfsutil.so.$(libbtrfsutil_major) -o $@
 
 libbtrfsutil.a: $(libbtrfsutil_objects)


### PR DESCRIPTION
libbtrfs.so already has user's LDFLAGS applied.
The change also applies those to libbtrfsutil.so.

Reported-by: Michał Górny
Bug: https://bugs.gentoo.org/686284