### PR TITLE
restore: Fix input buffer handling

### DIFF
--- a/cmds-restore.c
+++ b/cmds-restore.c
@@ -488,14 +488,14 @@ enum loop_response {
 
 static enum loop_response ask_to_continue(const char *file)
 {
-	char buf[2];
+	char buf[16];
 	char *ret;
 
 	printf("We seem to be looping a lot on %s, do you want to keep going "
 	       "on ? (y/N/a): ", file);
 again:
-	ret = fgets(buf, 2, stdin);
-	if (*ret == '\n' || tolower(*ret) == 'n')
+	ret = fgets(buf, 16, stdin);
+	if (!ret || *ret == '\n' || tolower(*ret) == 'n')
 		return LOOP_STOP;
 	if (tolower(*ret) == 'a')
 		return LOOP_DONTASK;


### PR DESCRIPTION
`fgets` consumes **n-1** bytes from input buffer.

When a user types `y\n`, the newline is left in the buffer.
As a result, the next `fgets` uses that `\n` as answer without waiting for the user to type. 

This patch also fix a bug that dereference the `ret` without checking if it's `NULL`.