### PR TITLE
Show user filesystem usage by block type and profile

### DIFF
--- a/Documentation/btrfs-filesystem.asciidoc
+++ b/Documentation/btrfs-filesystem.asciidoc
@@ -267,20 +267,28 @@ with information about space usage:
 +
 -------------------------
 $ btrfs filesystem usage /path
-WARNING: cannot read detailed chunk info, RAID5/6 numbers will be incorrect, run as root
 Overall:
-    Device size:                   1.82TiB
-    Device allocated:              1.17TiB
-    Device unallocated:          669.99GiB
+    Device size:                  10.92TiB
+    Device allocated:              5.92TiB
+    Device unallocated:            5.00TiB
+    Device data used:              5.91TiB
+    Device metadata used:         11.92GiB
+    Device system used:          672.00KiB
+    Device total used:             5.92TiB
     Device missing:                  0.00B
-    Used:                          1.14TiB
-    Free (estimated):            692.57GiB      (min: 692.57GiB)
-    Data ratio:                       1.00
-    Metadata ratio:                   1.00
+    User total size:               5.46TiB
+    User data used:                2.95TiB
+    User metadata used:            7.00GiB
+    User system used:             64.00MiB
+    User total used:               2.96TiB
+    User free (estimated):         2.50TiB      (min: 2.50TiB)
+    Data ratio:                       2.00
+    Metadata ratio:                   2.00
     Global reserve:              512.00MiB      (used: 0.00B)
 -------------------------
 +
-The root user will also see stats broken down by block group types:
+The root user will also see stats broken down by block group types,
+if flag -d is provided:
 +
 -------------------------
 Data,single: Size:1.15TiB, Used:1.13TiB
@@ -300,6 +308,8 @@ Unallocated:
 +
 -b|--raw::::
 raw numbers in bytes, without the 'B' suffix
+-d::::
+show usage stats per device
 -h|--human-readable::::
 print human friendly numbers, base 1024, this is the default
 -H::::
@@ -316,6 +326,8 @@ show sizes in MiB, or MB with --si
 show sizes in GiB, or GB with --si
 -t|--tbytes::::
 show sizes in TiB, or TB with --si
+-P::::
+show user usage stats per profile
 -T::::
 show data in tabular format
 +

--- a/Documentation/btrfs-filesystem.asciidoc
+++ b/Documentation/btrfs-filesystem.asciidoc
@@ -269,15 +269,15 @@ with information about space usage:
 $ btrfs filesystem usage /path
 Overall:
     Device size:                  10.92TiB
-    Device allocated:              5.92TiB
-    Device unallocated:            5.00TiB
+    Device allocated:              5.93TiB
+    Device unallocated:            4.99TiB
     Device data used:              5.91TiB
-    Device metadata used:         11.92GiB
+    Device metadata used:         12.23GiB
     Device system used:          672.00KiB
     Device total used:             5.92TiB
     Device missing:                  0.00B
     User total size:               5.46TiB
-    User data used:                2.95TiB
+    User data used:                2.96TiB
     User metadata used:            7.00GiB
     User system used:             64.00MiB
     User total used:               2.96TiB
@@ -291,17 +291,29 @@ The root user will also see stats broken down by block group types,
 if flag -d is provided:
 +
 -------------------------
-Data,single: Size:1.15TiB, Used:1.13TiB
-   /dev/sdb        1.15TiB
+Data,RAID10: Size:2.96TiB, Used:2.96TiB
+   /dev/sdb        1.48TiB
+   /dev/sdc        1.48TiB
+   /dev/sdd        1.48TiB
+   /dev/sde        1.48TiB
 
-Metadata,single: Size:12.00GiB, Used:6.45GiB
-   /dev/sdb       12.00GiB
+Metadata,RAID10: Size:7.00GiB, Used:6.12GiB
+   /dev/sdb        3.50GiB
+   /dev/sdc        3.50GiB
+   /dev/sdd        3.50GiB
+   /dev/sde        3.50GiB
 
-System,single: Size:32.00MiB, Used:144.00KiB
+System,RAID10: Size:64.00MiB, Used:336.00KiB
    /dev/sdb       32.00MiB
+   /dev/sdc       32.00MiB
+   /dev/sdd       32.00MiB
+   /dev/sde       32.00MiB
 
 Unallocated:
-   /dev/sdb      669.99GiB
+   /dev/sdb        1.25TiB
+   /dev/sdc        1.25TiB
+   /dev/sdd        1.25TiB
+   /dev/sde        1.25TiB
 -------------------------
 +
 `Options`

--- a/cmds/filesystem-usage.c
+++ b/cmds/filesystem-usage.c
@@ -973,6 +973,7 @@ static int cmd_filesystem_usage(const struct cmd_struct *cmd,
 	unsigned unit_mode;
 	int i;
 	int more_than_one = 0;
+	int all_devices = 0;
 	int tabular = 0;
 
 	unit_mode = get_unit_mode_from_arg(&argc, argv, 1);
@@ -981,11 +982,14 @@ static int cmd_filesystem_usage(const struct cmd_struct *cmd,
 	while (1) {
 		int c;
 
-		c = getopt(argc, argv, "T");
+		c = getopt(argc, argv, "dT");
 		if (c < 0)
 			break;
 
 		switch (c) {
+		case 'd':
+			all_devices = 1;
+			break;
 		case 'T':
 			tabular = 1;
 			break;
@@ -1022,9 +1026,11 @@ static int cmd_filesystem_usage(const struct cmd_struct *cmd,
 				devinfo, devcount, argv[i], unit_mode);
 		if (ret)
 			goto cleanup;
-		printf("\n");
-		ret = print_filesystem_usage_by_chunk(fd, chunkinfo, chunkcount,
-				devinfo, devcount, argv[i], unit_mode, tabular);
+		if (all_devices) {
+			printf("\n");
+			ret = print_filesystem_usage_by_chunk(fd, chunkinfo, chunkcount,
+					devinfo, devcount, argv[i], unit_mode, tabular);
+		}
 cleanup:
 		close_file_or_dir(fd, dirstream);
 		free(chunkinfo);


### PR DESCRIPTION
This pull request provides the following changes.

1) Filesystem usage stats by device are shown only after specifying a new option -d.

2) Filesystem usage stats show now the user usage stats, which contrary to device usage depend on the RAID profiles, as total size, used sizes by group type (data, metadata, and  system) and their total. By specifying optional -P flag, stats per RAID profile are shown for each group type (which might be useful for inspection of filesystems with chunks of mixed profiles).

3) btrfs-filesystem man page has been updated to describe new flags.

Example output for `btrfs filesystem usage -P`:

```
Overall:
    Device size:                  10.92TiB
    Device allocated:              5.92TiB
    Device unallocated:            5.00TiB
    Device data used:              5.91TiB
    Device metadata used:         11.92GiB
    Device system used:          672.00KiB
    Device total used:             5.92TiB
    Device missing:                  0.00B
    User total size:               5.46TiB
    User data used:                2.95TiB
        raid10:                    2.95TiB
    User metadata used:            7.00GiB
        raid10:                    7.00GiB
    User system used:             64.00MiB
        raid10:                   64.00MiB
    User total used:               2.96TiB
    User free (estimated):         2.50TiB      (min: 2.50TiB)
    Data ratio:                       2.00
    Metadata ratio:                   2.00
    Global reserve:              512.00MiB      (used: 0.00B)
```