### PR TITLE
btrfs-progs: Fix printf formats

### DIFF
--- a/btrfs-crc.c
+++ b/btrfs-crc.c
@@ -52,7 +52,7 @@ int main(int argc, char **argv)
 			length = atol(optarg);
 			break;
 		case 'c':
-			sscanf(optarg, "%li", &checksum);
+			sscanf(optarg, "%lu", &checksum);
 			loop = 1;
 			break;
 		case 's':

--- a/btrfs-fragments.c
+++ b/btrfs-fragments.c
@@ -84,7 +84,7 @@ print_bg(FILE *html, char *name, u64 start, u64 len, u64 used, u64 flags,
 {
 	double frag = (double)areas / (len / 4096) * 2;
 
-	fprintf(html, "<p>%s chunk starts at %lld, size is %s, %.2f%% used, "
+	fprintf(html, "<p>%s chunk starts at %llu, size is %s, %.2f%% used, "
 		      "%.2f%% fragmented</p>\n", chunk_type(flags), start,
 		      pretty_size(len), 100.0 * used / len, 100.0 * frag);
 	fprintf(html, "<img src=\"%s\" border=\"1\" />\n", name);
@@ -264,8 +264,8 @@ list_fragments(int fd, u64 flags, char *dir)
 				bgflags = btrfs_block_group_flags(bg);
 				bgused = btrfs_block_group_used(bg);
 
-				printf("found block group %lld len %lld "
-					"flags %lld\n",
+				printf("found block group %llu len %llu "
+					"flags %llu\n",
 					btrfs_search_header_objectid(sh),
 					btrfs_search_header_offset(sh),
 					bgflags);
@@ -322,7 +322,7 @@ list_fragments(int fd, u64 flags, char *dir)
 				else
 					c = black;
 				if (btrfs_search_header_objectid(sh) > bgend) {
-					printf("WARN: extent %lld is without "
+					printf("WARN: extent %llu is without "
 						"block group\n",
 						btrfs_search_header_objectid(sh));
 					goto skip;

--- a/check/main.c
+++ b/check/main.c
@@ -5242,7 +5242,7 @@ static int process_extent_item(struct btrfs_root *root,
 	}
 	if (item_size < sizeof(*ei)) {
 		error(
-"corrupted or unsupported extent item found, item size=%u expect minimal size=%lu",
+"corrupted or unsupported extent item found, item size=%u expect minimal size=%zu",
 		      item_size, sizeof(*ei));
 		return -EIO;
 	}

--- a/common/utils.c
+++ b/common/utils.c
@@ -389,7 +389,7 @@ int pretty_size_snprintf(u64 size, char *str, size_t str_size, unsigned unit_mod
 
 	/* Unknown mode */
 	if (!base) {
-		fprintf(stderr, "INTERNAL ERROR: unknown unit base, mode %d\n",
+		fprintf(stderr, "INTERNAL ERROR: unknown unit base, mode %u\n",
 				unit_mode);
 		assert(0);
 		return -1;

--- a/ctree.c
+++ b/ctree.c
@@ -2540,7 +2540,7 @@ int btrfs_extend_item(struct btrfs_root *root, struct btrfs_path *path,
 	BUG_ON(slot < 0);
 	if (slot >= nritems) {
 		btrfs_print_leaf(leaf);
-		printk("slot %d too large, nritems %d\n", slot, nritems);
+		printk("slot %d too large, nritems %u\n", slot, nritems);
 		BUG_ON(1);
 	}
 
@@ -2631,7 +2631,7 @@ int btrfs_insert_empty_items(struct btrfs_trans_handle *trans,
 
 		if (old_data < data_end) {
 			btrfs_print_leaf(leaf);
-			printk("slot %d old_data %d data_end %d\n",
+			printk("slot %d old_data %u data_end %u\n",
 			       slot, old_data, data_end);
 			BUG_ON(1);
 		}

--- a/disk-io.c
+++ b/disk-io.c
@@ -128,7 +128,7 @@ static void print_tree_block_error(struct btrfs_fs_info *fs_info,
 			eb->start, btrfs_header_bytenr(eb));
 		break;
 	case BTRFS_BAD_LEVEL:
-		fprintf(stderr, "bad level, %u > %u\n",
+		fprintf(stderr, "bad level, %u > %d\n",
 			btrfs_header_level(eb), BTRFS_MAX_LEVEL);
 		break;
 	case BTRFS_BAD_NRITEMS:
@@ -814,7 +814,7 @@ int btrfs_check_fs_compatibility(struct btrfs_super_block *sb,
 		   ~BTRFS_FEATURE_INCOMPAT_SUPP;
 	if (features) {
 		printk("couldn't open because of unsupported "
-		       "option features (%Lx).\n",
+		       "option features (%llx).\n",
 		       (unsigned long long)features);
 		return -ENOTSUP;
 	}
@@ -836,7 +836,7 @@ int btrfs_check_fs_compatibility(struct btrfs_super_block *sb,
 		}
 		if (features & ~BTRFS_FEATURE_COMPAT_RO_SUPP) {
 			printk("couldn't open RDWR because of unsupported "
-			       "option features (%Lx).\n",
+			       "option features (%llx).\n",
 			       (unsigned long long)features);
 			return -ENOTSUP;
 		}

--- a/extent-tree.c
+++ b/extent-tree.c
@@ -1422,7 +1422,7 @@ again:
 	item_size = btrfs_item_size_nr(l, path->slots[0]);
 	if (item_size < sizeof(*item)) {
 		error(
-"unsupported or corrupted extent item, item size=%u expect minimal size=%lu",
+"unsupported or corrupted extent item, item size=%u expect minimal size=%zu",
 			item_size, sizeof(*item));
 		ret = -EUCLEAN;
 		goto out;
@@ -2027,7 +2027,7 @@ static int __free_extent(struct btrfs_trans_handle *trans,
 		       (unsigned long long)root_objectid,
 		       (unsigned long long)owner_objectid,
 		       (unsigned long long)owner_offset);
-		printf("path->slots[0]: %u path->nodes[0]:\n", path->slots[0]);
+		printf("path->slots[0]: %d path->nodes[0]:\n", path->slots[0]);
 		btrfs_print_leaf(path->nodes[0]);
 		ret = -EIO;
 		goto fail;
@@ -2037,7 +2037,7 @@ static int __free_extent(struct btrfs_trans_handle *trans,
 	item_size = btrfs_item_size_nr(leaf, extent_slot);
 	if (item_size < sizeof(*ei)) {
 		error(
-"unsupported or corrupted extent item, item size=%u expect minimal size=%lu",
+"unsupported or corrupted extent item, item size=%u expect minimal size=%zu",
 			item_size, sizeof(*ei));
 		ret = -EUCLEAN;
 		goto fail;
@@ -3766,7 +3766,7 @@ static int run_delayed_tree_ref(struct btrfs_trans_handle *trans,
 	ref_root = ref->root;
 
 	if (node->ref_mod != 1) {
-		printf("btree block(%llu) has %d references rather than 1: action %d ref_root %llu parent %llu",
+		printf("btree block(%llu) has %d references rather than 1: action %u ref_root %llu parent %llu",
 			node->bytenr, node->ref_mod, node->action, ref_root,
 			parent);
 		return -EIO;

--- a/kerncompat.h
+++ b/kerncompat.h
@@ -98,7 +98,7 @@ static inline void warning_trace(const char *assertion, const char *filename,
 	if (!val)
 		return;
 	fprintf(stderr,
-		"%s:%d: %s: Warning: assertion `%s` failed, value %ld\n",
+		"%s:%u: %s: Warning: assertion `%s` failed, value %ld\n",
 		filename, line, func, assertion, val);
 #ifndef BTRFS_DISABLE_BACKTRACE
 	print_trace();
@@ -111,7 +111,7 @@ static inline void bugon_trace(const char *assertion, const char *filename,
 	if (!val)
 		return;
 	fprintf(stderr,
-		"%s:%d: %s: BUG_ON `%s` triggered, value %ld\n",
+		"%s:%u: %s: BUG_ON `%s` triggered, value %ld\n",
 		filename, line, func, assertion, val);
 #ifndef BTRFS_DISABLE_BACKTRACE
 	print_trace();

--- a/print-tree.c
+++ b/print-tree.c
@@ -472,7 +472,7 @@ void print_extent_item(struct extent_buffer *eb, int slot, int metadata)
 			printf("\t\textent data backref root ");
 			print_objectid(stdout,
 		(unsigned long long)btrfs_extent_data_ref_root(eb, dref), 0);
-			printf(" objectid %llu offset %lld count %u\n",
+			printf(" objectid %llu offset %llu count %u\n",
 			       (unsigned long long)btrfs_extent_data_ref_objectid(eb, dref),
 			       btrfs_extent_data_ref_offset(eb, dref),
 			       btrfs_extent_data_ref_count(eb, dref));
@@ -819,7 +819,7 @@ void btrfs_print_key(struct btrfs_disk_key *disk_key)
 		if (objectid == BTRFS_TREE_RELOC_OBJECTID)
 			print_objectid(stdout, offset, type);
 		else
-			printf("%lld", offset);
+			printf("%llu", offset);
 		printf(")");
 		break;
 	default:
@@ -966,7 +966,7 @@ static void print_dev_stats(struct extent_buffer *eb,
 	if (known < size) {
 		printf("\t\tunknown stats item bytes %u", size - known);
 		for (i = BTRFS_DEV_STAT_VALUES_MAX; i * sizeof(__le64) < size; i++) {
-			printf("\t\tunknown item %u offset %zu value %llu\n",
+			printf("\t\tunknown item %d offset %zu value %llu\n",
 				i, i * sizeof(__le64),
 				btrfs_dev_stats_value(eb, stats, i));
 		}
@@ -1052,7 +1052,7 @@ static void print_qgroup_status(struct extent_buffer *eb, int slot)
 	memset(flags_str, 0, sizeof(flags_str));
 	qgroup_flags_to_str(btrfs_qgroup_status_flags(eb, qg_status),
 					flags_str);
-	printf("\t\tversion %llu generation %llu flags %s scan %lld\n",
+	printf("\t\tversion %llu generation %llu flags %s scan %llu\n",
 		(unsigned long long)btrfs_qgroup_status_version(eb, qg_status),
 		(unsigned long long)btrfs_qgroup_status_generation(eb, qg_status),
 		flags_str,
@@ -1174,7 +1174,7 @@ void btrfs_print_leaf(struct extent_buffer *eb)
 	header_flags_to_str(flags, flags_str);
 	nr = btrfs_header_nritems(eb);
 
-	printf("leaf %llu items %d free space %d generation %llu owner ",
+	printf("leaf %llu items %u free space %d generation %llu owner ",
 		(unsigned long long)btrfs_header_bytenr(eb), nr,
 		btrfs_leaf_free_space(eb),
 		(unsigned long long)btrfs_header_generation(eb));
@@ -1219,9 +1219,9 @@ void btrfs_print_leaf(struct extent_buffer *eb)
 		type = btrfs_disk_key_type(&disk_key);
 		offset = btrfs_disk_key_offset(&disk_key);
 
-		printf("\titem %d ", i);
+		printf("\titem %u ", i);
 		btrfs_print_key(&disk_key);
-		printf(" itemoff %d itemsize %d\n",
+		printf(" itemoff %u itemsize %u\n",
 			btrfs_item_offset(eb, item),
 			btrfs_item_size(eb, item));
 
@@ -1478,7 +1478,7 @@ void btrfs_print_tree(struct extent_buffer *eb, bool follow, int traverse)
 		warning(
 		"node nr_items corrupted, has %u limit %u, continue anyway",
 			nr, BTRFS_NODEPTRS_PER_EXTENT_BUFFER(eb));
-	printf("node %llu level %d items %d free %u generation %llu owner ",
+	printf("node %llu level %d items %u free %u generation %llu owner ",
 	       (unsigned long long)eb->start,
 	        btrfs_header_level(eb), nr,
 		(u32)BTRFS_NODEPTRS_PER_EXTENT_BUFFER(eb) - nr,

--- a/quick-test.c
+++ b/quick-test.c
@@ -107,7 +107,7 @@ int main(int ac, char **av) {
 		fprintf(stderr, "Open ctree failed\n");
 		exit(1);
 	}
-	printf("node %p level %d total ptrs %d free spc %lu\n", root->node,
+	printf("node %p level %d total ptrs %u free spc %lu\n", root->node,
 	        btrfs_header_level(root->node),
 		btrfs_header_nritems(root->node),
 		(unsigned long)BTRFS_NODEPTRS_PER_BLOCK(root->fs_info) -

--- a/random-test.c
+++ b/random-test.c
@@ -398,7 +398,7 @@ int main(int ac, char **av)
 			fflush(stdout);
 		}
 		if (i && i % 5000 == 0) {
-			printf("open & close, root level %d nritems %d\n",
+			printf("open & close, root level %d nritems %u\n",
 				btrfs_header_level(&root->node->node.header),
 				btrfs_header_nritems(&root->node->node.header));
 			close_ctree(root, &super);

--- a/tests/fssum.c
+++ b/tests/fssum.c
@@ -272,7 +272,7 @@ sum_file_data_permissive(int fd, sum_t *dst)
 			for (old = i; buf[i] != 0 && i < ret; ++i)
 				;
 			if (verbose >= 2)
-				fprintf(stderr, "adding %u non-zeros to sum\n",
+				fprintf(stderr, "adding %d non-zeros to sum\n",
 					i - (int)old);
 			sum_add(dst, buf + old, i - old);
 		}


### PR DESCRIPTION
sizeof returns size_t, not unsigned long.

Signed-off-by: Rosen Penev <rosenp@gmail.com>