### PR TITLE
asciidoctor v2.0.0 droped docbook45 backend.

### DIFF
--- a/Documentation/Makefile.in
+++ b/Documentation/Makefile.in
@@ -57,7 +57,7 @@ ifeq (@ASCIIDOC_TOOL@,asciidoctor)
 ASCIIDOC = @ASCIIDOCTOR@
 ASCIIDOC_ARGS = -abtrfs_version=$(BTRFS_VERSION)
 ASCIIDOC_HTML = xhtml5
-ASCIIDOC_DOCBOOK = docbook45
+ASCIIDOC_DOCBOOK = docbook5
 ASCIIDOC_DEPS = 
 endif
 


### PR DESCRIPTION
See https://github.com/asciidoctor/asciidoctor/releases/tag/v2.0.0

Signed-off-by: Dimitri John Ledkov <xnox@ubuntu.com>