### PR TITLE
doc: update btrfs man page to explain compression level support

### DIFF
--- a/Documentation/btrfs-man5.asciidoc
+++ b/Documentation/btrfs-man5.asciidoc
@@ -125,9 +125,9 @@ The upper bound is not forced, but a warning is printed if it's more than 300
 seconds (5 minutes). Use with care.
 
 *compress*::
-*compress='type'*::
+*compress='type[:level]'*::
 *compress-force*::
-*compress-force='type'*::
+*compress-force='type[:level]'*::
 (default: off)
 +
 Control BTRFS file data compression.  Type may be specified as 'zlib',
@@ -135,6 +135,12 @@ Control BTRFS file data compression.  Type may be specified as 'zlib',
 is specified, 'zlib' is used.  If 'compress-force' is specified,
 then compression will always be attempted, but the data may end up uncompressed
 if the compression would make them larger.
++
+Both 'zlib' and 'zstd' (since v5.1) expose the compression level as a tunable
+knob with higher levels trading speed and memory ('zstd') for higher compression
+ratios. This can be set by appending a colon and the desired level. Zlib accepts
+the range [1, 9] and zstd accepts [1, 15]. If no level is set, both currently
+use a default level of 3.
 +
 Otherwise some simple heuristics are applied to detect an incompressible file.
 If the first blocks written to a file are not compressible, the whole file is


### PR DESCRIPTION
As of 5.1, btrfs now supports compression levels for zstd. Let users
know about this in the man page.

Signed-off-by: Dennis Zhou <dennis@kernel.org>