### PR TITLE
kerncompat.h: define BTRFS_DISABLE_BACKTRACE when building with uClibc

### DIFF
--- a/kerncompat.h
+++ b/kerncompat.h
@@ -32,7 +32,7 @@
 
 #include <features.h>
 
-#ifndef __GLIBC__
+#if !defined(__GLIBC__) || defined(__UCLIBC__)
 #ifndef BTRFS_DISABLE_BACKTRACE
 #define BTRFS_DISABLE_BACKTRACE
 #endif


### PR DESCRIPTION
uClibc does not provide backtrace() nor <execinfo.h>. When building
btrfs-progs, passing --disable-backtrace is enough to make it build with
uClibc. But once btrfs-progs is installed and another program/library
includes kerncompat.h, it fails to build with uClibc, because
BTRFS_DISABLE_BACKTRACE is not defined.

The most correct fix for this would be to have kerncompat.h generated
from kerncompat.h.in during the btrfs-progs build process, and tuned
depending on autoconf/automake variables. But as a quick fix that
follows the current strategy, we simply tweak the existing __GLIBC__
conditional. Indeed, uClibc pretends to be glibc and defines __GLIBC__,
but it does not replace it completely, hence the need to define
BTRFS_DISABLE_BACKTRACE when __GLIBC__ is not defined *or* when
__UCLIBC__ is defined.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/btrfs-progs/0002-kerncompat.h-define-BTRFS_DISABLE_BACKTRACE-when-bui.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>