### PR TITLE
Makefile: fix #214 missing volumes.o

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ cmds_objects = cmds/subvolume.o cmds/filesystem.o cmds/device.o cmds/scrub.o \
 	       cmds/inspect-dump-super.o cmds/inspect-tree-stats.o cmds/filesystem-du.o \
 	       mkfs/common.o check/mode-common.o check/mode-lowmem.o
 libbtrfs_objects = send-stream.o send-utils.o kernel-lib/rbtree.o btrfs-list.o \
-		   kernel-lib/radix-tree.o extent-cache.o extent_io.o \
+		   kernel-lib/radix-tree.o extent-cache.o extent_io.o volumes.o \
 		   kernel-lib/crc32c.o common/messages.o \
 		   uuid-tree.o utils-lib.o common/rbtree-utils.o
 libbtrfs_headers = send-stream.h send-utils.h send.h kernel-lib/rbtree.h btrfs-list.h \


### PR DESCRIPTION
#214 

# The problem to fix

`extent_io.o` depends `volumes.o`, but it's missing from Makefile.

# Whait I did

add `volumes.o` to `libbtrfs_objects`

# Checks

Snapper in my environment didn't run because the problem.
But after this fix, I confirm that it runs successfully.