### PR TITLE
Documentation: btrfs-subvolume: Clarify the default list sort order

### DIFF
--- a/Documentation/btrfs-subvolume.asciidoc
+++ b/Documentation/btrfs-subvolume.asciidoc
@@ -144,6 +144,7 @@ Other;;
 print the result as a table.
 
 Sorting;;
+By dafault the subvolumes will be sorted by subvolume ID ascending.
 -G [+|-]<value>::::
 list subvolumes in the filesystem that its generation is
 >=, \<= or = value. \'\+' means >= value, \'-' means \<= value, If there is


### PR DESCRIPTION
By default, "btrfs subvolume list" will show the subvolumes sorted by
subovlume id, in ascending order. Make this explicit in subvolume man
page.

Signed-off-by: Marcos Paulo de Souza <mpdesouza@suse.com>