### PR TITLE
btrfs-progs: Fix typo

### DIFF
--- a/props.c
+++ b/props.c
@@ -183,7 +183,7 @@ const struct prop_handler prop_handlers[] = {
 	},
 	{
 		.name = "compression",
-		.desc = "compression algorighm for the file or directory",
+		.desc = "compression algorithm for the file or directory",
 		.read_only = 0,
 	 	.types = prop_object_inode, prop_compression
 	},


### PR DESCRIPTION
Noticed this spelling error when I ran `btrfs property list` earlier today and grepped the source to find the culprit.