### PR TITLE
Documentation: Don't erase XMLTO_EXTRA contents

### DIFF
--- a/Documentation/Makefile.in
+++ b/Documentation/Makefile.in
@@ -66,7 +66,6 @@ ASCIIDOC_DEPS =
 endif
 
 MANPAGE_XSL = manpage-normal.xsl
-XMLTO_EXTRA =
 INSTALL = @INSTALL@
 RM = @RM@
 RMDIR = @RMDIR@


### PR DESCRIPTION
XMLTO_EXTRA is defined above, and then appended to if `asciidoctor` is
used to generate the manual pages.  The second definition was clearing
the value of this variable, which caused builds with asciidoctor to
fail with:

```
    [XMLTO]  btrfs-ioctl.3
xmlto: /usr/src/packages/user/btrfs-progs/src/btrfs-progs-v5.4/Documentation/btrfs-ioctl.xml does not validate (status 3)
xmlto: Fix document syntax or use --skip-validation option
validity error : no DTD found!
Document /usr/src/packages/user/btrfs-progs/src/btrfs-progs-v5.4/Documentation/btrfs-ioctl.xml does not validate
make[1]: *** [Makefile:114: btrfs-ioctl.3] Error 13
```

Fixes: 669f56177 ("btrfs-progs: docs: use docbook5 backend for asciidoctor")