### PR TITLE
Improved asciidoc syntax to fix rendering issues

### DIFF
--- a/Documentation/btrfs-replace.asciidoc
+++ b/Documentation/btrfs-replace.asciidoc
@@ -67,10 +67,10 @@ operation finishes (or is cancelled)
 EXAMPLES
 --------
 
-Replacing an online drive with a bigger one
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.Replacing an online drive with a bigger one
+====
 
-Given the filesystem:
+Given the following filesystem mounted at `/mnt/my-vault`
 
 ----
 Label: 'MyVault'  uuid: ae20903e-b72d-49ba-b944-901fc6d888a1
@@ -82,14 +82,14 @@ Label: 'MyVault'  uuid: ae20903e-b72d-49ba-b944-901fc6d888a1
 In order to replace '/dev/sda' ('devid 1') with a bigger drive located at
 '/dev/sdc' you would run the following:
 
-[source,shell]
+[source,bash]
 ----
 btrfs replace start 1 /dev/sdc /mnt/my-vault/
 ----
 
-You can monitor progress by:
+You can monitor progress via:
 
-[source,shell]
+[source,bash]
 ----
 btrfs replace status /mnt/my-vault/
 ----
@@ -97,10 +97,11 @@ btrfs replace status /mnt/my-vault/
 After the replacement is complete, as per the docs at `btrfs-filesystem`(8) in
 order to use the entire storage space of the new drive you need to run:
 
-[source,shell]
+[source,bash]
 ----
 btrfs filesystem resize 1:max /mnt/my-vault/
 ----
+====
 
 EXIT STATUS
 -----------


### PR DESCRIPTION
The drive replacement example doesn't render correctly in Google Chrome. This PR should fix that. Unfortunately, the Github preview rendering doesn't seem to care so much about the syntax so it renders ok.

![Screenshot from 2020-04-18 22-39-13](https://user-images.githubusercontent.com/7005614/79669681-d9276700-81c5-11ea-948d-2d0533910c56.png)