### PR TITLE
libbtrfsutil: Fix btrfs_util_delete_subvolume docs

### DIFF
--- a/libbtrfsutil/btrfsutil.h
+++ b/libbtrfsutil/btrfsutil.h
@@ -470,6 +470,11 @@ enum btrfs_util_error btrfs_util_create_snapshot_fd2(int fd, int parent_fd,
  * btrfs_util_delete_subvolume() - Delete a subvolume or snapshot.
  * @path: Path of the subvolume to delete.
  * @flags: Bitmask of BTRFS_UTIL_DELETE_SUBVOLUME_* flags.
+ * 
+ * This requires appropriate privilege (CAP_SYS_ADMIN).
+ * NOTE: Since 4.18 it is possible to delete a subvolume using rmdir. The sysfs
+ * file /sys/fs/btrfs/features/rmdir_subvol indicates whether this feature is
+ * enabled or not.
  *
  * Return: %BTRFS_UTIL_OK on success, non-zero error code on failure.
  */


### PR DESCRIPTION
Added "This requires appropriate privilege (CAP_SYS_ADMIN).".
Fixes #252 