### PR TITLE
Make scrub summary easier to read

### DIFF
--- a/cmds/scrub.c
+++ b/cmds/scrub.c
@@ -294,7 +294,7 @@ static void print_scrub_dev(struct btrfs_ioctl_dev_info_args *di,
 				struct btrfs_scrub_progress *p, int raw,
 				const char *append, struct scrub_stats *ss)
 {
-	printf("scrub device %s (id %llu) %s\n", di->path, di->devid,
+	printf("\nscrub device %s (id %llu) %s\n", di->path, di->devid,
 	       append ? append : "");
 
 	_print_scrub_ss(ss);

--- a/cmds/scrub.c
+++ b/cmds/scrub.c
@@ -294,7 +294,7 @@ static void print_scrub_dev(struct btrfs_ioctl_dev_info_args *di,
 				struct btrfs_scrub_progress *p, int raw,
 				const char *append, struct scrub_stats *ss)
 {
-	printf("\nscrub device %s (id %llu) %s\n", di->path, di->devid,
+	printf("\nScrub device %s (id %llu) %s\n", di->path, di->devid,
 	       append ? append : "");
 
 	_print_scrub_ss(ss);


### PR DESCRIPTION
Currently most btrfs commands separate their output with empty lines which makes them more human readable. The scrub cmd when used with -d arg to show per device information does not. It makes it harder to find values for current disk because they are not separated from each other. This commit adds an empty line after each device summary to make it match other btrfs cmd outputs.