### PR TITLE
btrfs-progs: docs: add info about "single" profile requirements for swapfile

### DIFF
--- a/Documentation/btrfs-man5.asciidoc
+++ b/Documentation/btrfs-man5.asciidoc
@@ -659,6 +659,7 @@ swap subsystem:
 * swapfile - the containing subvolume cannot be snapshotted
 * swapfile - must be preallocated
 * swapfile - must be nodatacow (ie. also nodatasum)
+* swapfile - must have 'single' data profile
 * swapfile - must not be compressed
  
 The limitations come namely from the COW-based design and mapping layer of


### PR DESCRIPTION
The limitation is there since first commit implementing swapfiles support.

Signed-off-by: Tomasz Torcz <tomek@pipebreaker.pl>