### PR TITLE
btrfs-progs: check: fixed segmentation fault

### DIFF
--- a/kernel-shared/ctree.c
+++ b/kernel-shared/ctree.c
@@ -927,7 +927,7 @@ static int balance_level(struct btrfs_trans_handle *trans,
 			if (wret)
 				ret = wret;
 
-			root_sub_used(root, right->len);
+			root_sub_used(root, blocksize);
 			wret = btrfs_free_extent(trans, root, bytenr,
 						 blocksize, 0,
 						 root->root_key.objectid,


### PR DESCRIPTION
I tested it, it actually fixes #296, repairing my filesystem seems to work again.
Thanks a lot to the original author of that line for quick answer!