### PR TITLE
common/utils.c: drop include on sys/sysinfo.h

### DIFF
--- a/common/utils.c
+++ b/common/utils.c
@@ -24,7 +24,6 @@
 #include <sys/mount.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <sys/sysinfo.h>
 #include <uuid/uuid.h>
 #include <fcntl.h>
 #include <unistd.h>


### PR DESCRIPTION
Drop include on `sys/sysinfo.h` to avoid the following build failure on musl:

```
In file included from /usr/lfs/hdd_v1/rc-buildroot-test/scripts/instance-0/output-1/host/i586-buildroot-linux-musl/sysroot/usr/include/linux/kernel.h:4,
                 from ./kerncompat.h:31,
                 from common/utils.c:42:
/usr/lfs/hdd_v1/rc-buildroot-test/scripts/instance-0/output-1/host/i586-buildroot-linux-musl/sysroot/usr/include/linux/sysinfo.h:7:8: error: redefinition of 'struct sysinfo'
    7 | struct sysinfo {
      |        ^~~~~~~
In file included from common/utils.c:27:
/usr/lfs/hdd_v1/rc-buildroot-test/scripts/instance-0/output-1/host/i586-buildroot-linux-musl/sysroot/usr/include/sys/sysinfo.h:10:8: note: originally defined here
   10 | struct sysinfo {
      |        ^~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/16f44fb9dea72a7079e8e5517e760dd79d2724cc

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>