### PR TITLE
Fix incorrect statement

### DIFF
--- a/Documentation/mkfs.btrfs.asciidoc
+++ b/Documentation/mkfs.btrfs.asciidoc
@@ -160,8 +160,7 @@ features that mkfs.btrfs supports run:
 *-R|--runtime-features <feature1>[,<feature2>...]*::
 A list of features that be can enabled at mkfs time, otherwise would have
 to be turned on a mounted filesystem.
-Although no runtime feature is enabled by default,
-to disable a feature, prefix it with '^'.
+To disable a feature, prefix it with '^'.
 +
 See section *RUNTIME FEATURES* for more details.  To see all available
 runtime features that mkfs.btrfs supports run:


### PR DESCRIPTION
Since free-space-tree is enabled by default in kernel 5.15, it is incorrect to state that no runtime options are enabled by default.