### PR TITLE
mkfs/main.c: fix build without zoned

### DIFF
--- a/mkfs/main.c
+++ b/mkfs/main.c
@@ -1349,11 +1349,13 @@ int BOX_MAIN(mkfs)(int argc, char **argv)
 	if (ret)
 		goto error;
 
+#if BTRFS_ZONED
 	if (zoned && (!zoned_profile_supported(metadata_profile) ||
 		      !zoned_profile_supported(data_profile))) {
 		error("zoned mode does not yet support RAID/DUP profiles, please specify '-d single -m single' manually");
 		goto error;
 	}
+#endif /* BTRFS_ZONED */
 
 	dev_cnt--;
 


### PR DESCRIPTION
Fix the following build failure raised when zoned is disabled since version 5.16.1 and https://github.com/kdave/btrfs-progs/commit/88895a920ff5b0969ec22fdc9f4511b17dd14806:

```
mkfs/main.o: In function `main':
main.c:(.text.startup+0xc90): undefined reference to `zoned_profile_supported'
```

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>