### PR TITLE
btrfs-progs: prop: add datacow inode property

### DIFF
--- a/Documentation/btrfs-man5.asciidoc
+++ b/Documentation/btrfs-man5.asciidoc
@@ -712,7 +712,7 @@ To create and activate a swapfile run the following commands:
 
 --------------------
 # truncate -s 0 swapfile
-# chattr +C swapfile
+# btrfs property set swapfile datacow no
 # fallocate -l 2G swapfile
 # chmod 0600 swapfile
 # mkswap swapfile

--- a/Documentation/btrfs-property.rst
+++ b/Documentation/btrfs-property.rst
@@ -48,6 +48,9 @@ get [-t <type>] <object> [<name>]
         compression
                 compression algorithm set for an inode, possible values: *lzo*, *zlib*, *zstd*.
                 To disable compression use "" (empty string), *no* or *none*.
+        datacow
+                copy on write flag for an inode: *no* or *yes*.
+                This is the same as ``chattr``/``lsattr`` *+C* flag.
 
 list [-t <type>] <object>
         Lists available properties with their descriptions for the given object.

--- a/Documentation/ch-swapfile.rst
+++ b/Documentation/ch-swapfile.rst
@@ -36,7 +36,7 @@ To create and activate a swapfile run the following commands:
 .. code-block:: bash
 
         # truncate -s 0 swapfile
-        # chattr +C swapfile
+        # btrfs property set swapfile datacow no
         # fallocate -l 2G swapfile
         # chmod 0600 swapfile
         # mkswap swapfile

--- a/tests/cli-tests/017-btrfs-property/test.sh
+++ b/tests/cli-tests/017-btrfs-property/test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# test btrfs property commands
+
+source "$TEST_TOP/common"
+
+# compare with lsattr to make sure
+check_global_prereq lsattr
+
+setup_root_helper
+prepare_test_dev
+
+run_check_mkfs_test_dev
+run_check_mount_test_dev
+
+run_check $SUDO_HELPER touch "$TEST_MNT/file"
+run_check $SUDO_HELPER "$TOP/btrfs" property set "$TEST_MNT/file" datacow no
+run_check_stdout $SUDO_HELPER "$TOP/btrfs" property get "$TEST_MNT/file" datacow |
+	grep -q "datacow=no" || _fail "datacow wasn't no"
+run_check_stdout $SUDO_HELPER lsattr "$TEST_MNT/file" |
+	grep -q -- "C.* " || _fail "lsattr didn't agree NOCOW flag is set"
+run_check $SUDO_HELPER "$TOP/btrfs" property set "$TEST_MNT/file" datacow yes
+run_check_stdout $SUDO_HELPER "$TOP/btrfs" property get "$TEST_MNT/file" datacow |
+	grep -q "datacow=yes" || _fail "datacow wasn't yes"
+
+run_check_umount_test_dev


### PR DESCRIPTION
Hello.

```
The btrfs property documentation states that it is an unified and
user-friendly method to tune btrfs properties instead of chattr,
so let's add something for datacow as well.
```

A few remarks:
 - please tell me if you prefer this sent on linux-btrfs@vger list, I don't mind either workflow but I saw other open PRs here and you seem to use github issues at least.
 - naming: I wasn't sure whether to name it datacow with yes/no, or making it "nodatacow" with true/false (readonly uses true/false so it might make more sense to use the later), I've picked datacow to avoid double-negation for ease of understanding but happy to change it to anything
 - documentation: I got a bit confused with the rst and asciidoc file, as things got "converted" to rst recently but the asciidoc file didn't get removed. Should I have updated both?

Thanks!