### PR TITLE
btrfs-progs: check: add check for overlong xattr names

### DIFF
--- a/check/mode-original.h
+++ b/check/mode-original.h
@@ -187,6 +187,7 @@ struct unaligned_extent_rec_t {
 #define I_ERR_INVALID_IMODE		(1 << 19)
 #define I_ERR_INVALID_GEN		(1 << 20)
 #define I_ERR_INVALID_NLINK		(1 << 21)
+#define I_ERR_INVALID_XATTR		(1 << 22)
 
 struct inode_record {
 	struct list_head backrefs;


### PR DESCRIPTION
While working on my Windows driver, I found that it was inadvertently allowing users to create xattrs with names longer than 255 bytes, which wasn't being picked up by btrfs-check.

If the Linux driver encounters a file with an invalid xattr like this, it makes the whole directory it's in inaccessible. If it's the root directory, it'll refuse to mount the filesystem entirely.