### PR TITLE
btrfs-convert: fix bugs in and improve readability of reserved range handling logic

### DIFF
--- a/convert/common.h
+++ b/convert/common.h
@@ -64,4 +64,25 @@ struct btrfs_convert_context {
 int make_convert_btrfs(int fd, struct btrfs_mkfs_config *cfg,
 			      struct btrfs_convert_context *cctx);
 
+/*
+ * Represents a simple contiguous range.
+ *
+ * For multiple or non-contiguous ranges, use extent_cache_tree from
+ * extent-cache.c
+ */
+struct simple_range {
+	u64 start;
+	u64 len;
+};
+
+/*
+ * Simple range functions
+ */
+
+/* Get range end (exclusive) */
+static inline u64 range_end(const struct simple_range *range)
+{
+	return (range->start + range->len);
+}
+
 #endif

--- a/convert/main.c
+++ b/convert/main.c
@@ -250,10 +250,13 @@ static int create_image_file_range(struct btrfs_trans_handle *trans,
 		/*
 		 *      |-- reserved --|
 		 * |-- range --|
+		 * or
+		 *      |-- reserved --|
+		 * |------- range -------|
 		 * Leading part may still create a file extent
 		 */
 		if (bytenr < reserved->start &&
-		    bytenr + len >= range_end(reserved)) {
+		    bytenr + len > reserved->start) {
 			len = min_t(u64, len, reserved->start - bytenr);
 			break;
 		}

--- a/convert/main.c
+++ b/convert/main.c
@@ -236,7 +236,7 @@ static int create_image_file_range(struct btrfs_trans_handle *trans,
 
 		/*
 		 * |-- reserved --|
-		 *         |--range---|
+		 *         |-- range --|
 		 * or
 		 * |---- reserved ----|
 		 *    |-- range --|
@@ -248,8 +248,8 @@ static int create_image_file_range(struct btrfs_trans_handle *trans,
 		}
 
 		/*
-		 *      |---reserved---|
-		 * |----range-------|
+		 *      |-- reserved --|
+		 * |-- range --|
 		 * Leading part may still create a file extent
 		 */
 		if (bytenr < reserved->start &&

--- a/convert/main.c
+++ b/convert/main.c
@@ -207,9 +207,9 @@ static int create_image_file_range(struct btrfs_trans_handle *trans,
 {
 	struct cache_extent *cache;
 	struct btrfs_block_group *bg_cache;
+	const struct simple_range *reserved;
 	u64 len = *ret_len;
 	u64 disk_bytenr;
-	int i;
 	int ret;
 	u32 datacsum = convert_flags & CONVERT_FLAG_DATACSUM;
 
@@ -231,9 +231,8 @@ static int create_image_file_range(struct btrfs_trans_handle *trans,
 	 * Or we will insert a hole into current image file, and later
 	 * migrate block will fail as there is already a file extent.
 	 */
-	for (i = 0; i < ARRAY_SIZE(btrfs_reserved_ranges); i++) {
-		const struct simple_range *reserved = &btrfs_reserved_ranges[i];
-
+	reserved = intersect_with_reserved(bytenr, len);
+	if (reserved) {
 		/*
 		 * |-- reserved --|
 		 *         |-- range --|
@@ -242,7 +241,7 @@ static int create_image_file_range(struct btrfs_trans_handle *trans,
 		 *    |-- range --|
 		 * Skip to reserved range end
 		 */
-		if (bytenr >= reserved->start && bytenr < range_end(reserved)) {
+		if (bytenr >= reserved->start) {
 			*ret_len = range_end(reserved) - bytenr;
 			return 0;
 		}
@@ -255,11 +254,7 @@ static int create_image_file_range(struct btrfs_trans_handle *trans,
 		 * |------- range -------|
 		 * Leading part may still create a file extent
 		 */
-		if (bytenr < reserved->start &&
-		    bytenr + len > reserved->start) {
-			len = min_t(u64, len, reserved->start - bytenr);
-			break;
-		}
+		len = min_t(u64, len, reserved->start - bytenr);
 	}
 
 	/* Check if we are going to insert regular file extent, or hole */

--- a/convert/source-fs.c
+++ b/convert/source-fs.c
@@ -53,7 +53,7 @@ int ext2_acl_count(size_t size)
 	}
 }
 
-static u64 intersect_with_reserved(u64 bytenr, u64 num_bytes)
+const struct simple_range *intersect_with_reserved(u64 bytenr, u64 num_bytes)
 {
 	int i;
 
@@ -62,9 +62,9 @@ static u64 intersect_with_reserved(u64 bytenr, u64 num_bytes)
 
 		if (bytenr < range_end(range) &&
 		    bytenr + num_bytes > range->start)
-			return range_end(range);
+			return range;
 	}
-	return 0;
+	return NULL;
 }
 
 void init_convert_context(struct btrfs_convert_context *cctx)
@@ -89,15 +89,15 @@ int block_iterate_proc(u64 disk_block, u64 file_block,
 		              struct blk_iterate_data *idata)
 {
 	int ret = 0;
-	u64 reserved_boundary;
+	const struct simple_range *reserved;
 	int do_barrier;
 	struct btrfs_root *root = idata->root;
 	struct btrfs_block_group *cache;
 	u32 sectorsize = root->fs_info->sectorsize;
 	u64 bytenr = disk_block * sectorsize;
 
-	reserved_boundary = intersect_with_reserved(bytenr, sectorsize);
-	do_barrier = reserved_boundary || disk_block >= idata->boundary;
+	reserved = intersect_with_reserved(bytenr, sectorsize);
+	do_barrier = reserved || disk_block >= idata->boundary;
 	if ((idata->num_blocks > 0 && do_barrier) ||
 	    (file_block > idata->first_block + idata->num_blocks) ||
 	    (disk_block != idata->disk_block + idata->num_blocks)) {
@@ -117,8 +117,8 @@ int block_iterate_proc(u64 disk_block, u64 file_block,
 				goto fail;
 		}
 
-		if (reserved_boundary) {
-			bytenr = reserved_boundary;
+		if (reserved) {
+			bytenr = range_end(reserved);
 		} else {
 			cache = btrfs_lookup_block_group(root->fs_info, bytenr);
 			BUG_ON(!cache);

--- a/convert/source-fs.c
+++ b/convert/source-fs.c
@@ -61,7 +61,7 @@ static u64 intersect_with_reserved(u64 bytenr, u64 num_bytes)
 		const struct simple_range *range = &btrfs_reserved_ranges[i];
 
 		if (bytenr < range_end(range) &&
-		    bytenr + num_bytes >= range->start)
+		    bytenr + num_bytes > range->start)
 			return range_end(range);
 	}
 	return 0;

--- a/convert/source-fs.h
+++ b/convert/source-fs.h
@@ -25,6 +25,8 @@
 
 extern const struct simple_range btrfs_reserved_ranges[3];
 
+const struct simple_range *intersect_with_reserved(u64 bytenr, u64 num_bytes);
+
 struct task_info;
 
 struct task_ctx {

--- a/convert/source-fs.h
+++ b/convert/source-fs.h
@@ -23,17 +23,6 @@
 
 #define CONV_IMAGE_SUBVOL_OBJECTID BTRFS_FIRST_FREE_OBJECTID
 
-/*
- * Represents a simple contiguous range.
- *
- * For multiple or non-contiguous ranges, use extent_cache_tree from
- * extent-cache.c
- */
-struct simple_range {
-	u64 start;
-	u64 len;
-};
-
 extern const struct simple_range btrfs_reserved_ranges[3];
 
 struct task_info;
@@ -161,15 +150,5 @@ int read_disk_extent(struct btrfs_root *root, u64 bytenr,
 		            u32 num_bytes, char *buffer);
 int record_file_blocks(struct blk_iterate_data *data,
 			      u64 file_block, u64 disk_block, u64 num_blocks);
-
-/*
- * Simple range functions
- *
- * Get range end (exclusive)
- */
-static inline u64 range_end(const struct simple_range *range)
-{
-	return (range->start + range->len);
-}
 
 #endif


### PR DESCRIPTION
See individual commit descriptions for details. Reserved ranges are the parts of the original filesystem that have to be relocated to make room for btrfs data structures during a conversion. I noticed some bugs and some needless duplication in the code that works with them while investigating #297 and #349, and these changes address those.

I also believe I've found a root cause for #297 and #349 (invalid assumption that all mappings are 1:1 in `csum_disk_extent()`), but the fix for that isn't ready yet, so I'll submit it as a separate PR.