### PR TITLE
Update links to btrfs manual pages in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ administration.
 
 This repository hosts following utilities and also documentation:
 
-* **btrfs** &mdash; the main administration tool ([manual page](https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs))
-* **mkfs.btrfs** &mdash; utility to create the filesystem ([manual page](https://btrfs.wiki.kernel.org/index.php/Manpage/mkfs.btrfs))
+* **btrfs** &mdash; the main administration tool ([manual page](https://btrfs.readthedocs.io/en/latest/btrfs.html))
+* **mkfs.btrfs** &mdash; utility to create the filesystem ([manual page](https://btrfs.readthedocs.io/en/latest/mkfs.btrfs.html))
 * all-in-one binary in the busybox style with mkfs.btrfs, btrfs-image and other tools built-in ([standalone tools](https://github.com/kdave/btrfs-progs/blob/master/Documentation/btrfs.rst#standalone-tools))
 * **libbtrfsutil** (LGPL v2.1) &mdash; C and python 3 bindings, see [libbtrfsutil/README.md](libbtrfsutil/README.md) for more
 * manual pages and documentation source published at [btrfs.readthedocs.io](https://btrfs.rtfd.io)


### PR DESCRIPTION
The online man pages of the btrfs utilities seem to have been moved to `readthedocs.io`;
this updates the references in the README accordingly.