### PR TITLE
Static builds should pick up EXTRA_LDFLAGS and SUBST_LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ LIBBTRFS_LIBS = $(LIBS_BASE) $(LIBS_CRYPTO)
 
 # Static compilation flags
 STATIC_CFLAGS = $(CFLAGS) -ffunction-sections -fdata-sections -DSTATIC_BUILD
-STATIC_LDFLAGS = -static -Wl,--gc-sections
+STATIC_LDFLAGS = $(SUBST_LDFLAGS) $(EXTRA_LDFLAGS) -static -Wl,--gc-sections
 STATIC_LIBS = $(STATIC_LIBS_BASE)
 
 # don't use FORTIFY with sparse because glibc with FORTIFY can


### PR DESCRIPTION
Concrete use-case:
 - I want a static build to run in a small test VM.
 - RedHat regrettably does not provide `util-linux` static libraries like `libuuid.a` and `libblkid.a`. 
 - So, one has to build them from source.
 - Installing these to `/usr` is lame.
 - This change lets me do `make btrfs.static EXTRA_LDFLAGS=-L/path/to/util-linux-2.38/.libs`