### PR TITLE
Update ch-mount-options.rst :: Add main title

### DIFF
--- a/Documentation/ch-mount-options.rst
+++ b/Documentation/ch-mount-options.rst
@@ -1,3 +1,6 @@
+BTRFS SPECIFIC MOUNT OPTIONS
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 This section describes mount options specific to BTRFS.  For the generic mount
 options please refer to ``mount(8)`` manual page. The options are sorted alphabetically
 (discarding the *no* prefix).


### PR DESCRIPTION
The header of the main section seems to be missing --> added.

This might fix the strange appearance on [readthedocs](https://btrfs.readthedocs.io)

![Screenshot_20230103_194341](https://user-images.githubusercontent.com/37483735/210421232-7f537352-37b3-4e97-8617-34a3b64c0ca2.png)

where all those options appear to be deprecated!
