### PR TITLE
crypto/blake2b-sse2.c: add missing ssse3 header

### DIFF
--- a/crypto/blake2b-sse2.c
+++ b/crypto/blake2b-sse2.c
@@ -23,6 +23,9 @@
 #ifdef HAVE_SSE2
 
 #include <emmintrin.h>
+#if defined(HAVE_SSSE3)
+#include <tmmintrin.h>
+#endif
 #if defined(HAVE_XOP)
 #include <x86intrin.h>
 #endif


### PR DESCRIPTION
Otherwise, the following error occurs:

| In file included from crypto/blake2b-sse2.c:30:
| crypto/blake2b-sse2.c: In function 'blake2b_compress_sse2': | crypto/blake2b-round.h:32:22: warning: implicit declaration of function '_mm_shuffle_epi8'; did you mean '_mm_shuffle_epi32'? [-Wimplicit-function-declaration]
|    32 |     : (-(c) == 24) ? _mm_shuffle_epi8((x), r24) \
|       |                      ^~~~~~~~~~~~~~~~