### PR TITLE
btrfs-progs: docs: fix name of "mountinfo" file in subvolume intro

### DIFF
--- a/Documentation/ch-subvolume-intro.rst
+++ b/Documentation/ch-subvolume-intro.rst
@@ -134,8 +134,8 @@ may change in the future.
 Mounting a read-write snapshot as read-only is possible and will not change the
 *ro* property and flag of the subvolume.
 
-The name of the mounted subvolume is stored in file ``/proc/self/mounts`` in the
-4th column:
+The name of the mounted subvolume is stored in file ``/proc/self/mountinfo`` in
+the 4th column:
 
 .. code-block::
 


### PR DESCRIPTION
The name of a mounted sub volume can not be found in `/proc/self/mounts` but in `/proc/self/mountinfo`.