### PR TITLE
btrfs-progs: handle case if fsid not in sysfs in device_is_seed

### DIFF
--- a/cmds/filesystem-usage.c
+++ b/cmds/filesystem-usage.c
@@ -726,7 +726,7 @@ static int device_is_seed(int fd, const char *dev_path, u64 devid, const u8 *mnt
 		close(sysfs_fd);
 	}
 
-	if (ret) {
+	if (ret || sysfs_fd < 0) {
 		ret = dev_to_fsid(dev_path, fsid);
 		if (ret)
 			return ret;


### PR DESCRIPTION
For older kernels, the sysfs interface providing the fsid may not be present yet. Since 32c2e57c65b9974c5ec709a6bf47d65040bdf9a1, the fallback to the previous approach to determine the fsid was not used anymore.

Ensure negative return values of `sysfs_open_fsid_file` are handled by falling back to the `dev_to_fsid` in this case.