### PR TITLE
btrfs-progs: stop use of legacy *64 interfaces

### DIFF
--- a/cmds/rescue-chunk-recover.c
+++ b/cmds/rescue-chunk-recover.c
@@ -754,7 +754,7 @@ static int scan_one_device(void *dev_scan_struct)
 		if (is_super_block_address(bytenr))
 			bytenr += rc->sectorsize;
 
-		if (pread64(fd, buf->data, rc->nodesize, bytenr) <
+		if (pread(fd, buf->data, rc->nodesize, bytenr) <
 		    rc->nodesize)
 			break;
 
@@ -1874,7 +1874,7 @@ static int check_one_csum(int fd, u64 start, u32 len, u32 tree_csum,
 	data = malloc(len);
 	if (!data)
 		return -1;
-	ret = pread64(fd, data, len, start);
+	ret = pread(fd, data, len, start);
 	if (ret < 0 || ret != len) {
 		ret = -1;
 		goto out;

--- a/image/main.c
+++ b/image/main.c
@@ -691,7 +691,7 @@ static int flush_pending(struct metadump_struct *md, int done)
 		if (start == BTRFS_SUPER_INFO_OFFSET) {
 			int fd = get_dev_fd(md->root);
 
-			ret = pread64(fd, async->buffer, size, start);
+			ret = pread(fd, async->buffer, size, start);
 			if (ret < size) {
 				free(async->buffer);
 				free(async);
@@ -1366,7 +1366,7 @@ static void write_backup_supers(int fd, u8 *buf)
 			break;
 		btrfs_set_super_bytenr(super, bytenr);
 		csum_block(buf, BTRFS_SUPER_INFO_SIZE);
-		ret = pwrite64(fd, buf, BTRFS_SUPER_INFO_SIZE, bytenr);
+		ret = pwrite(fd, buf, BTRFS_SUPER_INFO_SIZE, bytenr);
 		if (ret < BTRFS_SUPER_INFO_SIZE) {
 			if (ret < 0)
 				error(
@@ -1487,12 +1487,12 @@ static int restore_one_work(struct mdrestore_struct *mdres,
 				else
 					bytenr = logical;
 
-				ret = pwrite64(outfd, buffer + offset, chunk_size, bytenr);
+				ret = pwrite(outfd, buffer + offset, chunk_size, bytenr);
 				if (ret != chunk_size)
 					goto write_error;
 
 				if (physical_dup)
-					ret = pwrite64(outfd, buffer + offset,
+					ret = pwrite(outfd, buffer + offset,
 						       chunk_size, physical_dup);
 				if (ret != chunk_size)
 					goto write_error;
@@ -2451,7 +2451,7 @@ static int fixup_device_size(struct btrfs_trans_handle *trans,
 	}
 	if (S_ISREG(buf.st_mode)) {
 		/* Don't forget to enlarge the real file */
-		ret = ftruncate64(out_fd, dev_size);
+		ret = ftruncate(out_fd, dev_size);
 		if (ret < 0) {
 			error("failed to enlarge result image: %m");
 			return -errno;
@@ -2910,7 +2910,7 @@ static int restore_metadump(const char *input, FILE *out, int old_restore,
 			goto out;
 		}
 		if (S_ISREG(st.st_mode) && st.st_size < dev_size) {
-			ret = ftruncate64(fileno(out), dev_size);
+			ret = ftruncate(fileno(out), dev_size);
 			if (ret < 0) {
 				error(
 		"failed to enlarge result image file from %llu to %llu: %m",
@@ -3007,7 +3007,7 @@ static int update_disk_super_on_device(struct btrfs_fs_info *info,
 	memcpy(dev_item->fsid, fs_uuid, BTRFS_UUID_SIZE);
 	csum_block((u8 *)&disk_super, BTRFS_SUPER_INFO_SIZE);
 
-	ret = pwrite64(fp, &disk_super, BTRFS_SUPER_INFO_SIZE, BTRFS_SUPER_INFO_OFFSET);
+	ret = pwrite(fp, &disk_super, BTRFS_SUPER_INFO_SIZE, BTRFS_SUPER_INFO_OFFSET);
 	if (ret != BTRFS_SUPER_INFO_SIZE) {
 		if (ret < 0) {
 			errno = ret;

--- a/kernel-shared/zoned.c
+++ b/kernel-shared/zoned.c
@@ -194,7 +194,7 @@ static int sb_write_pointer(int fd, struct blk_zone *zones, u64 *wp_ret)
 			bytenr = ((zones[i].start + zones[i].len)
 				   << SECTOR_SHIFT) - BTRFS_SUPER_INFO_SIZE;
 
-			ret = pread64(fd, buf[i], BTRFS_SUPER_INFO_SIZE, bytenr);
+			ret = pread(fd, buf[i], BTRFS_SUPER_INFO_SIZE, bytenr);
 			if (ret != BTRFS_SUPER_INFO_SIZE)
 				return -EIO;
 			super[i] = (struct btrfs_super_block *)&buf[i];
@@ -515,8 +515,8 @@ size_t btrfs_sb_io(int fd, void *buf, off_t offset, int rw)
 	/* We can call pread/pwrite if 'fd' is non-zoned device/file */
 	if (zone_size_sector == 0) {
 		if (rw == READ)
-			return pread64(fd, buf, count, offset);
-		return pwrite64(fd, buf, count, offset);
+			return pread(fd, buf, count, offset);
+		return pwrite(fd, buf, count, offset);
 	}
 
 	ASSERT(IS_ALIGNED(zone_size_sector, sb_size_sector));

--- a/kernel-shared/zoned.h
+++ b/kernel-shared/zoned.h
@@ -150,9 +150,9 @@ int btrfs_wipe_temporary_sb(struct btrfs_fs_devices *fs_devices);
 #else
 
 #define sbread(fd, buf, offset) \
-	pread64(fd, buf, BTRFS_SUPER_INFO_SIZE, offset)
+	pread(fd, buf, BTRFS_SUPER_INFO_SIZE, offset)
 #define sbwrite(fd, buf, offset) \
-	pwrite64(fd, buf, BTRFS_SUPER_INFO_SIZE, offset)
+	pwrite(fd, buf, BTRFS_SUPER_INFO_SIZE, offset)
 
 static inline int btrfs_reset_dev_zone(int fd, struct blk_zone *zone)
 {

--- a/mkfs/main.c
+++ b/mkfs/main.c
@@ -460,14 +460,14 @@ static int zero_output_file(int out_fd, u64 size)
 	/* Only zero out the first 1M */
 	loop_num = SZ_1M / SZ_4K;
 	for (i = 0; i < loop_num; i++) {
-		written = pwrite64(out_fd, buf, SZ_4K, location);
+		written = pwrite(out_fd, buf, SZ_4K, location);
 		if (written != SZ_4K)
 			ret = -EIO;
 		location += SZ_4K;
 	}
 
 	/* Then enlarge the file to size */
-	written = pwrite64(out_fd, buf, 1, size - 1);
+	written = pwrite(out_fd, buf, 1, size - 1);
 	if (written < 1)
 		ret = -EIO;
 	return ret;

--- a/mkfs/rootdir.c
+++ b/mkfs/rootdir.c
@@ -340,7 +340,7 @@ static int add_file_items(struct btrfs_trans_handle *trans,
 			goto end;
 		}
 
-		ret_read = pread64(fd, buffer, st->st_size, bytes_read);
+		ret_read = pread(fd, buffer, st->st_size, bytes_read);
 		if (ret_read == -1) {
 			error("cannot read %s at offset %llu length %llu: %m",
 				path_name, bytes_read, (unsigned long long)st->st_size);
@@ -386,7 +386,7 @@ again:
 
 		memset(eb->data, 0, sectorsize);
 
-		ret_read = pread64(fd, eb->data, sectorsize, file_pos +
+		ret_read = pread(fd, eb->data, sectorsize, file_pos +
 				   bytes_read);
 		if (ret_read == -1) {
 			error("cannot read %s at offset %llu length %u: %m",
@@ -929,7 +929,7 @@ int btrfs_mkfs_shrink_fs(struct btrfs_fs_info *fs_info, u64 *new_size_ret,
 	u64 new_size;
 	struct btrfs_device *device;
 	struct list_head *cur;
-	struct stat64 file_stat;
+	struct stat file_stat;
 	int nr_devs = 0;
 	int ret;
 
@@ -963,14 +963,14 @@ int btrfs_mkfs_shrink_fs(struct btrfs_fs_info *fs_info, u64 *new_size_ret,
 		*new_size_ret = new_size;
 
 	if (shrink_file_size) {
-		ret = fstat64(device->fd, &file_stat);
+		ret = fstat(device->fd, &file_stat);
 		if (ret < 0) {
 			error("failed to stat devid %llu: %m", device->devid);
 			return ret;
 		}
 		if (!S_ISREG(file_stat.st_mode))
 			return ret;
-		ret = ftruncate64(device->fd, new_size);
+		ret = ftruncate(device->fd, new_size);
 		if (ret < 0) {
 			error("failed to truncate device file of devid %llu: %m",
 				device->devid);

--- a/tests/fsstress.c
+++ b/tests/fsstress.c
@@ -411,7 +411,7 @@ int		freq_table_size;
 char		*homedir;
 int		*ilist;
 int		ilistlen;
-off64_t		maxfsize;
+off_t		maxfsize;
 char		*myprog;
 int		namerand;
 int		nameseq;
@@ -458,7 +458,7 @@ int	get_fname(int, long, pathname_t *, flist_t **, fent_t **, int *);
 void	init_pathname(pathname_t *);
 int	lchown_path(pathname_t *, uid_t, gid_t);
 int	link_path(pathname_t *, pathname_t *);
-int	lstat64_path(pathname_t *, struct stat64 *);
+int	lstat_path(pathname_t *, struct stat *);
 void	make_freq_table(void);
 int	mkdir_path(pathname_t *, mode_t);
 int	mknod_path(pathname_t *, mode_t, dev_t);
@@ -472,9 +472,9 @@ int	rename_path(pathname_t *, pathname_t *, int);
 int	rmdir_path(pathname_t *);
 void	separate_pathname(pathname_t *, char *, pathname_t *);
 void	show_ops(int, char *);
-int	stat64_path(pathname_t *, struct stat64 *);
+int	stat_path(pathname_t *, struct stat *);
 int	symlink_path(const char *, pathname_t *);
-int	truncate64_path(pathname_t *, off64_t);
+int	truncate64_path(pathname_t *, off_t);
 int	unlink_path(pathname_t *);
 void	usage(void);
 void	write_freq(void);
@@ -662,10 +662,10 @@ int main(int argc, char **argv)
 	}
 	sprintf(buf, "fss%x", (unsigned int)getpid());
 	fd = creat(buf, 0666);
-	if (lseek64(fd, (off64_t)(MAXFSIZE32 + 1ULL), SEEK_SET) < 0)
-		maxfsize = (off64_t)MAXFSIZE32;
+	if (lseek64(fd, (off_t)(MAXFSIZE32 + 1ULL), SEEK_SET) < 0)
+		maxfsize = (off_t)MAXFSIZE32;
 	else
-		maxfsize = (off64_t)MAXFSIZE;
+		maxfsize = (off_t)MAXFSIZE;
 	make_freq_table();
 	dcache_init();
 	setlinebuf(stdout);
@@ -998,12 +998,12 @@ void
 check_cwd(void)
 {
 #ifdef DEBUG
-	struct stat64	statbuf;
+	struct stat	statbuf;
 	int ret;
 
-	ret = stat64(".", &statbuf);
+	ret = stat(".", &statbuf);
 	if (ret != 0) {
-		fprintf(stderr, "fsstress: check_cwd stat64() returned %d with errno: %d (%m)\n",
+		fprintf(stderr, "fsstress: check_cwd stat() returned %d with errno: %d (%m)\n",
 			ret, errno);
 		goto out;
 	}
@@ -1171,7 +1171,7 @@ again:
 void
 doproc(void)
 {
-	struct stat64	statbuf;
+	struct stat	statbuf;
 	char		buf[10];
 	char		cmd[64];
 	opnum_t		opno;
@@ -1182,7 +1182,7 @@ doproc(void)
 	dividend = (operations + execute_freq) / (execute_freq + 1);
 	sprintf(buf, "p%x", procid);
 	(void)mkdir(buf, 0777);
-	if (chdir(buf) < 0 || stat64(".", &statbuf) < 0) {
+	if (chdir(buf) < 0 || stat(".", &statbuf) < 0) {
 		perror(buf);
 		_exit(1);
 	}
@@ -1214,7 +1214,7 @@ doproc(void)
 		 * the forced shutdown happened.
 		 */
 		if (errtag != 0 && opno % 100 == 0)  {
-			rval = stat64(".", &statbuf);
+			rval = stat(".", &statbuf);
 			if (rval == EIO)  {
 				fprintf(stderr, "Detected EIO\n");
 				goto errout;
@@ -1537,18 +1537,18 @@ link_path(pathname_t *name1, pathname_t *name2)
 }
 
 int
-lstat64_path(pathname_t *name, struct stat64 *sbuf)
+lstat_path(pathname_t *name, struct stat *sbuf)
 {
 	char		buf[NAME_MAX + 1];
 	pathname_t	newname;
 	int		rval;
 
-	rval = lstat64(name->path, sbuf);
+	rval = lstat(name->path, sbuf);
 	if (rval >= 0 || errno != ENAMETOOLONG)
 		return rval;
 	separate_pathname(name, buf, &newname);
 	if (chdir(buf) == 0) {
-		rval = lstat64_path(&newname, sbuf);
+		rval = lstat_path(&newname, sbuf);
 		assert(chdir("..") == 0);
 	}
 	free_pathname(&newname);
@@ -1870,18 +1870,18 @@ show_ops(int flag, char *lead_str)
 }
 
 int
-stat64_path(pathname_t *name, struct stat64 *sbuf)
+stat_path(pathname_t *name, struct stat *sbuf)
 {
 	char		buf[NAME_MAX + 1];
 	pathname_t	newname;
 	int		rval;
 
-	rval = stat64(name->path, sbuf);
+	rval = stat(name->path, sbuf);
 	if (rval >= 0 || errno != ENAMETOOLONG)
 		return rval;
 	separate_pathname(name, buf, &newname);
 	if (chdir(buf) == 0) {
-		rval = stat64_path(&newname, sbuf);
+		rval = stat_path(&newname, sbuf);
 		assert(chdir("..") == 0);
 	}
 	free_pathname(&newname);
@@ -1913,7 +1913,7 @@ symlink_path(const char *name1, pathname_t *name)
 }
 
 int
-truncate64_path(pathname_t *name, off64_t length)
+truncate64_path(pathname_t *name, off_t length)
 {
 	char		buf[NAME_MAX + 1];
 	pathname_t	newname;
@@ -2026,7 +2026,7 @@ non_btrfs_freq(const char *path)
 		ops[btrfs_ops[i]].freq = 0;
 }
 
-void inode_info(char *str, size_t sz, struct stat64 *s, int verbose)
+void inode_info(char *str, size_t sz, struct stat *s, int verbose)
 {
 	if (verbose)
 		snprintf(str, sz, "[%ld %ld %d %d %lld %lld]",
@@ -2100,8 +2100,8 @@ allocsp_f(opnum_t opno, long r)
 	int		fd;
 	struct xfs_flock64	fl;
 	int64_t		lr;
-	off64_t		off;
-	struct stat64	stb;
+	off_t		off;
+	struct stat	stb;
 	int		v;
 	char		st[1024];
 
@@ -2122,9 +2122,9 @@ allocsp_f(opnum_t opno, long r)
 		free_pathname(&f);
 		return;
 	}
-	if (fstat64(fd, &stb) < 0) {
+	if (fstat(fd, &stb) < 0) {
 		if (v)
-			printf("%d/%lld: allocsp - fstat64 %s failed %d\n",
+			printf("%d/%lld: allocsp - fstat %s failed %d\n",
 				procid, opno, f.path, errno);
 		free_pathname(&f);
 		close(fd);
@@ -2132,7 +2132,7 @@ allocsp_f(opnum_t opno, long r)
 	}
 	inode_info(st, sizeof(st), &stb, v);
 	lr = ((int64_t)random() << 32) + random();
-	off = (off64_t)(lr % MIN(stb.st_size + (1024 * 1024), MAXFSIZE));
+	off = (off_t)(lr % MIN(stb.st_size + (1024 * 1024), MAXFSIZE));
 	off %= maxfsize;
 	fl.l_whence = SEEK_SET;
 	fl.l_start = off;
@@ -2159,8 +2159,8 @@ do_aio_rw(opnum_t opno, long r, int flags)
 	int		fd = -1;
 	size_t		len;
 	int64_t		lr;
-	off64_t		off;
-	struct stat64	stb;
+	off_t		off;
+	struct stat	stb;
 	int		v;
 	char		st[1024];
 	char		*dio_env;
@@ -2184,9 +2184,9 @@ do_aio_rw(opnum_t opno, long r, int flags)
 			       procid, opno, f.path, e);
 		goto aio_out;
 	}
-	if (fstat64(fd, &stb) < 0) {
+	if (fstat(fd, &stb) < 0) {
 		if (v)
-			printf("%d/%lld: do_aio_rw - fstat64 %s failed %d\n",
+			printf("%d/%lld: do_aio_rw - fstat %s failed %d\n",
 			       procid, opno, f.path, errno);
 		goto aio_out;
 	}
@@ -2230,13 +2230,13 @@ do_aio_rw(opnum_t opno, long r, int flags)
 	}
 
 	if (iswrite) {
-		off = (off64_t)(lr % MIN(stb.st_size + (1024 * 1024), MAXFSIZE));
+		off = (off_t)(lr % MIN(stb.st_size + (1024 * 1024), MAXFSIZE));
 		off -= (off % align);
 		off %= maxfsize;
 		memset(buf, nameseq & 0xff, len);
 		io_prep_pwrite(&iocb, fd, buf, len, off);
 	} else {
-		off = (off64_t)(lr % stb.st_size);
+		off = (off_t)(lr % stb.st_size);
 		off -= (off % align);
 		io_prep_pread(&iocb, fd, buf, len, off);
 	}
@@ -2277,8 +2277,8 @@ do_uring_rw(opnum_t opno, long r, int flags)
 	int		fd = -1;
 	size_t		len;
 	int64_t		lr;
-	off64_t		off;
-	struct stat64	stb;
+	off_t		off;
+	struct stat	stb;
 	int		v;
 	char		st[1024];
 	struct io_uring_sqe	*sqe;
@@ -2304,9 +2304,9 @@ do_uring_rw(opnum_t opno, long r, int flags)
 			       procid, opno, f.path, e);
 		goto uring_out;
 	}
-	if (fstat64(fd, &stb) < 0) {
+	if (fstat(fd, &stb) < 0) {
 		if (v)
-			printf("%d/%lld: do_uring_rw - fstat64 %s failed %d\n",
+			printf("%d/%lld: do_uring_rw - fstat %s failed %d\n",
 			       procid, opno, f.path, errno);
 		goto uring_out;
 	}
@@ -2336,12 +2336,12 @@ do_uring_rw(opnum_t opno, long r, int flags)
 	iovec.iov_base = buf;
 	iovec.iov_len = len;
 	if (iswrite) {
-		off = (off64_t)(lr % MIN(stb.st_size + (1024 * 1024), MAXFSIZE));
+		off = (off_t)(lr % MIN(stb.st_size + (1024 * 1024), MAXFSIZE));
 		off %= maxfsize;
 		memset(buf, nameseq & 0xff, len);
 		io_uring_prep_writev(sqe, fd, &iovec, 1, off);
 	} else {
-		off = (off64_t)(lr % stb.st_size);
+		off = (off_t)(lr % stb.st_size);
 		io_uring_prep_readv(sqe, fd, &iovec, 1, off);
 	}
 
@@ -2522,7 +2522,7 @@ bulkstat1_f(opnum_t opno, long r)
 	int		fd;
 	int		good;
 	__u64		ino;
-	struct stat64	s;
+	struct stat	s;
 	struct xfs_bstat	t;
 	int		v;
 	struct xfs_fsop_bulkreq bsr;
@@ -2534,7 +2534,7 @@ bulkstat1_f(opnum_t opno, long r)
 		init_pathname(&f);
 		if (!get_fname(FT_ANYm, r, &f, NULL, NULL, &v))
 			append_pathname(&f, ".");
-		ino = stat64_path(&f, &s) < 0 ? (ino64_t)r : s.st_ino;
+		ino = stat_path(&f, &s) < 0 ? (ino64_t)r : s.st_ino;
 		check_cwd();
 		free_pathname(&f);
 	} else {
@@ -2605,14 +2605,14 @@ clonerange_f(
 	struct file_clone_range	fcr;
 	struct pathname		fpath1;
 	struct pathname		fpath2;
-	struct stat64		stat1;
-	struct stat64		stat2;
+	struct stat		stat1;
+	struct stat		stat2;
 	char			inoinfo1[1024];
 	char			inoinfo2[1024];
-	off64_t			lr;
-	off64_t			off1;
-	off64_t			off2;
-	off64_t			max_off2;
+	off_t			lr;
+	off_t			off1;
+	off_t			off2;
+	off_t			max_off2;
 	size_t			len;
 	int			v1;
 	int			v2;
@@ -2660,17 +2660,17 @@ clonerange_f(
 	}
 
 	/* Get file stats */
-	if (fstat64(fd1, &stat1) < 0) {
+	if (fstat(fd1, &stat1) < 0) {
 		if (v1)
-			printf("%d/%lld: clonerange read - fstat64 %s failed %d\n",
+			printf("%d/%lld: clonerange read - fstat %s failed %d\n",
 				procid, opno, fpath1.path, errno);
 		goto out_fd2;
 	}
 	inode_info(inoinfo1, sizeof(inoinfo1), &stat1, v1);
 
-	if (fstat64(fd2, &stat2) < 0) {
+	if (fstat(fd2, &stat2) < 0) {
 		if (v2)
-			printf("%d/%lld: clonerange write - fstat64 %s failed %d\n",
+			printf("%d/%lld: clonerange write - fstat %s failed %d\n",
 				procid, opno, fpath2.path, errno);
 		goto out_fd2;
 	}
@@ -2688,7 +2688,7 @@ clonerange_f(
 	if (stat1.st_size == len)
 		off1 = 0;
 	else
-		off1 = (off64_t)(lr % MIN(stat1.st_size - len, MAXFSIZE));
+		off1 = (off_t)(lr % MIN(stat1.st_size - len, MAXFSIZE));
 	off1 %= maxfsize;
 	off1 = rounddown_64(off1, stat1.st_blksize);
 
@@ -2699,7 +2699,7 @@ clonerange_f(
 	max_off2 = MIN(stat2.st_size + (1024ULL * stat2.st_blksize), MAXFSIZE);
 	do {
 		lr = ((int64_t)random() << 32) + random();
-		off2 = (off64_t)(lr % max_off2);
+		off2 = (off_t)(lr % max_off2);
 		off2 %= maxfsize;
 		off2 = rounddown_64(off2, stat2.st_blksize);
 	} while (stat1.st_ino == stat2.st_ino && llabs(off2 - off1) < len);
@@ -2743,8 +2743,8 @@ copyrange_f(
 #ifdef HAVE_COPY_FILE_RANGE
 	struct pathname		fpath1;
 	struct pathname		fpath2;
-	struct stat64		stat1;
-	struct stat64		stat2;
+	struct stat		stat1;
+	struct stat		stat2;
 	char			inoinfo1[1024];
 	char			inoinfo2[1024];
 	loff_t			lr;
@@ -2802,17 +2802,17 @@ copyrange_f(
 	}
 
 	/* Get file stats */
-	if (fstat64(fd1, &stat1) < 0) {
+	if (fstat(fd1, &stat1) < 0) {
 		if (v1)
-			printf("%d/%lld: copyrange read - fstat64 %s failed %d\n",
+			printf("%d/%lld: copyrange read - fstat %s failed %d\n",
 				procid, opno, fpath1.path, errno);
 		goto out_fd2;
 	}
 	inode_info(inoinfo1, sizeof(inoinfo1), &stat1, v1);
 
-	if (fstat64(fd2, &stat2) < 0) {
+	if (fstat(fd2, &stat2) < 0) {
 		if (v2)
-			printf("%d/%lld: copyrange write - fstat64 %s failed %d\n",
+			printf("%d/%lld: copyrange write - fstat %s failed %d\n",
 				procid, opno, fpath2.path, errno);
 		goto out_fd2;
 	}
@@ -2829,7 +2829,7 @@ copyrange_f(
 	if (stat1.st_size == len)
 		off1 = 0;
 	else
-		off1 = (off64_t)(lr % MIN(stat1.st_size - len, MAXFSIZE));
+		off1 = (off_t)(lr % MIN(stat1.st_size - len, MAXFSIZE));
 	off1 %= maxfsize;
 
 	/*
@@ -2839,7 +2839,7 @@ copyrange_f(
 	max_off2 = MIN(stat2.st_size + (1024ULL * stat2.st_blksize), MAXFSIZE);
 	do {
 		lr = ((int64_t)random() << 32) + random();
-		off2 = (off64_t)(lr % max_off2);
+		off2 = (off_t)(lr % max_off2);
 		off2 %= maxfsize;
 	} while (stat1.st_ino == stat2.st_ino && llabs(off2 - off1) < len);
 
@@ -2900,13 +2900,13 @@ deduperange_f(
 #define INFO_SZ			1024
 	struct file_dedupe_range *fdr;
 	struct pathname		*fpath;
-	struct stat64		*stat;
+	struct stat		*stat;
 	char			*info;
-	off64_t			*off;
+	off_t			*off;
 	int			*v;
 	int			*fd;
 	int			nr;
-	off64_t			lr;
+	off_t			lr;
 	size_t			len;
 	int			ret;
 	int			i;
@@ -2938,7 +2938,7 @@ deduperange_f(
 		goto out_fdr;
 	}
 
-	stat = calloc(nr, sizeof(struct stat64));
+	stat = calloc(nr, sizeof(struct stat));
 	if (!stat) {
 		printf("%d/%lld: line %d error %d\n",
 			procid, opno, __LINE__, errno);
@@ -2952,7 +2952,7 @@ deduperange_f(
 		goto out_stats;
 	}
 
-	off = calloc(nr, sizeof(off64_t));
+	off = calloc(nr, sizeof(off_t));
 	if (!off) {
 		printf("%d/%lld: line %d error %d\n",
 			procid, opno, __LINE__, errno);
@@ -3017,9 +3017,9 @@ deduperange_f(
 	}
 
 	/* Get file stats */
-	if (fstat64(fd[0], &stat[0]) < 0) {
+	if (fstat(fd[0], &stat[0]) < 0) {
 		if (v[0])
-			printf("%d/%lld: deduperange read - fstat64 %s failed %d\n",
+			printf("%d/%lld: deduperange read - fstat %s failed %d\n",
 				procid, opno, fpath[0].path, errno);
 		goto out_fds;
 	}
@@ -3027,9 +3027,9 @@ deduperange_f(
 	inode_info(&info[0], INFO_SZ, &stat[0], v[0]);
 
 	for (i = 1; i < nr; i++) {
-		if (fstat64(fd[i], &stat[i]) < 0) {
+		if (fstat(fd[i], &stat[i]) < 0) {
 			if (v[i])
-				printf("%d/%lld: deduperange write - fstat64 %s failed %d\n",
+				printf("%d/%lld: deduperange write - fstat %s failed %d\n",
 					procid, opno, fpath[i].path, errno);
 			goto out_fds;
 		}
@@ -3049,7 +3049,7 @@ deduperange_f(
 	if (stat[0].st_size == len)
 		off[0] = 0;
 	else
-		off[0] = (off64_t)(lr % MIN(stat[0].st_size - len, MAXFSIZE));
+		off[0] = (off_t)(lr % MIN(stat[0].st_size - len, MAXFSIZE));
 	off[0] %= maxfsize;
 	off[0] = rounddown_64(off[0], stat[0].st_blksize);
 
@@ -3065,7 +3065,7 @@ deduperange_f(
 			if (stat[i].st_size <= len)
 				off[i] = 0;
 			else
-				off[i] = (off64_t)(lr % MIN(stat[i].st_size - len, MAXFSIZE));
+				off[i] = (off_t)(lr % MIN(stat[i].st_size - len, MAXFSIZE));
 			off[i] %= maxfsize;
 			off[i] = rounddown_64(off[i], stat[i].st_blksize);
 		} while (stat[0].st_ino == stat[i].st_ino &&
@@ -3179,8 +3179,8 @@ splice_f(opnum_t opno, long r)
 {
 	struct pathname		fpath1;
 	struct pathname		fpath2;
-	struct stat64		stat1;
-	struct stat64		stat2;
+	struct stat		stat1;
+	struct stat		stat2;
 	char			inoinfo1[1024];
 	char			inoinfo2[1024];
 	loff_t			lr;
@@ -3237,17 +3237,17 @@ splice_f(opnum_t opno, long r)
 	}
 
 	/* Get file stats */
-	if (fstat64(fd1, &stat1) < 0) {
+	if (fstat(fd1, &stat1) < 0) {
 		if (v1)
-			printf("%d/%lld: splice read - fstat64 %s failed %d\n",
+			printf("%d/%lld: splice read - fstat %s failed %d\n",
 				procid, opno, fpath1.path, errno);
 		goto out_fd2;
 	}
 	inode_info(inoinfo1, sizeof(inoinfo1), &stat1, v1);
 
-	if (fstat64(fd2, &stat2) < 0) {
+	if (fstat(fd2, &stat2) < 0) {
 		if (v2)
-			printf("%d/%lld: splice write - fstat64 %s failed %d\n",
+			printf("%d/%lld: splice write - fstat %s failed %d\n",
 				procid, opno, fpath2.path, errno);
 		goto out_fd2;
 	}
@@ -3264,7 +3264,7 @@ splice_f(opnum_t opno, long r)
 	if (stat1.st_size == len)
 		off1 = 0;
 	else
-		off1 = (off64_t)(lr % MIN(stat1.st_size - len, MAXFSIZE));
+		off1 = (off_t)(lr % MIN(stat1.st_size - len, MAXFSIZE));
 	off1 %= maxfsize;
 
 	/*
@@ -3273,7 +3273,7 @@ splice_f(opnum_t opno, long r)
 	 * past the current dest file EOF
 	 */
 	lr = ((int64_t)random() << 32) + random();
-	off2 = (off64_t)(lr % MIN(stat2.st_size + (1024ULL * stat2.st_blksize), MAXFSIZE));
+	off2 = (off_t)(lr % MIN(stat2.st_size + (1024ULL * stat2.st_blksize), MAXFSIZE));
 
 	/*
 	 * Since len, off1 and off2 will be changed later, preserve their
@@ -3431,8 +3431,8 @@ dread_f(opnum_t opno, long r)
 	int		fd;
 	size_t		len;
 	int64_t		lr;
-	off64_t		off;
-	struct stat64	stb;
+	off_t		off;
+	struct stat	stb;
 	int		v;
 	char		st[1024];
 	char		*dio_env;
@@ -3454,9 +3454,9 @@ dread_f(opnum_t opno, long r)
 		free_pathname(&f);
 		return;
 	}
-	if (fstat64(fd, &stb) < 0) {
+	if (fstat(fd, &stb) < 0) {
 		if (v)
-			printf("%d/%lld: dread - fstat64 %s failed %d\n",
+			printf("%d/%lld: dread - fstat %s failed %d\n",
 			       procid, opno, f.path, errno);
 		free_pathname(&f);
 		close(fd);
@@ -3491,7 +3491,7 @@ dread_f(opnum_t opno, long r)
 
 	align = (int64_t)diob.d_miniosz;
 	lr = ((int64_t)random() << 32) + random();
-	off = (off64_t)(lr % stb.st_size);
+	off = (off_t)(lr % stb.st_size);
 	off -= (off % align);
 	lseek64(fd, off, SEEK_SET);
 	len = (random() % FILELEN_MAX) + 1;
@@ -3521,8 +3521,8 @@ dwrite_f(opnum_t opno, long r)
 	int		fd;
 	size_t		len;
 	int64_t		lr;
-	off64_t		off;
-	struct stat64	stb;
+	off_t		off;
+	struct stat	stb;
 	int		v;
 	char		st[1024];
 	char		*dio_env;
@@ -3544,9 +3544,9 @@ dwrite_f(opnum_t opno, long r)
 		free_pathname(&f);
 		return;
 	}
-	if (fstat64(fd, &stb) < 0) {
+	if (fstat(fd, &stb) < 0) {
 		if (v)
-			printf("%d/%lld: dwrite - fstat64 %s failed %d\n",
+			printf("%d/%lld: dwrite - fstat %s failed %d\n",
 				procid, opno, f.path, errno);
 		free_pathname(&f);
 		close(fd);
@@ -3572,7 +3572,7 @@ dwrite_f(opnum_t opno, long r)
 
 	align = (int64_t)diob.d_miniosz;
 	lr = ((int64_t)random() << 32) + random();
-	off = (off64_t)(lr % MIN(stb.st_size + (1024 * 1024), MAXFSIZE));
+	off = (off_t)(lr % MIN(stb.st_size + (1024 * 1024), MAXFSIZE));
 	off -= (off % align);
 	lseek64(fd, off, SEEK_SET);
 	len = (random() % FILELEN_MAX) + 1;
@@ -3618,9 +3618,9 @@ do_fallocate(opnum_t opno, long r, int mode)
 	pathname_t	f;
 	int		fd;
 	int64_t		lr;
-	off64_t		off;
-	off64_t		len;
-	struct stat64	stb;
+	off_t		off;
+	off_t		len;
+	struct stat	stb;
 	int		v;
 	char		st[1024];
 
@@ -3640,9 +3640,9 @@ do_fallocate(opnum_t opno, long r, int mode)
 		return;
 	}
 	check_cwd();
-	if (fstat64(fd, &stb) < 0) {
+	if (fstat(fd, &stb) < 0) {
 		if (v)
-			printf("%d/%lld: do_fallocate - fstat64 %s failed %d\n",
+			printf("%d/%lld: do_fallocate - fstat %s failed %d\n",
 				procid, opno, f.path, errno);
 		free_pathname(&f);
 		close(fd);
@@ -3650,9 +3650,9 @@ do_fallocate(opnum_t opno, long r, int mode)
 	}
 	inode_info(st, sizeof(st), &stb, v);
 	lr = ((int64_t)random() << 32) + random();
-	off = (off64_t)(lr % MIN(stb.st_size + (1024 * 1024), MAXFSIZE));
+	off = (off_t)(lr % MIN(stb.st_size + (1024 * 1024), MAXFSIZE));
 	off %= maxfsize;
-	len = (off64_t)(random() % (1024 * 1024));
+	len = (off_t)(random() % (1024 * 1024));
 	/*
 	 * Collapse/insert range requires off and len to be block aligned,
 	 * make it more likely to be the case.
@@ -3733,8 +3733,8 @@ fiemap_f(opnum_t opno, long r)
 	pathname_t	f;
 	int		fd;
 	int64_t		lr;
-	off64_t		off;
-	struct stat64	stb;
+	off_t		off;
+	struct stat	stb;
 	int		v;
 	char		st[1024];
 	int blocks_to_map;
@@ -3757,9 +3757,9 @@ fiemap_f(opnum_t opno, long r)
 		free_pathname(&f);
 		return;
 	}
-	if (fstat64(fd, &stb) < 0) {
+	if (fstat(fd, &stb) < 0) {
 		if (v)
-			printf("%d/%lld: fiemap - fstat64 %s failed %d\n",
+			printf("%d/%lld: fiemap - fstat %s failed %d\n",
 				procid, opno, f.path, errno);
 		free_pathname(&f);
 		close(fd);
@@ -3777,7 +3777,7 @@ fiemap_f(opnum_t opno, long r)
 		return;
 	}
 	lr = ((int64_t)random() << 32) + random();
-	off = (off64_t)(lr % MIN(stb.st_size + (1024 * 1024), MAXFSIZE));
+	off = (off_t)(lr % MIN(stb.st_size + (1024 * 1024), MAXFSIZE));
 	off %= maxfsize;
 	fiemap->fm_flags = random() & (FIEMAP_FLAGS_COMPAT | 0x10000);
 	fiemap->fm_extent_count = blocks_to_map;
@@ -3806,8 +3806,8 @@ freesp_f(opnum_t opno, long r)
 	int		fd;
 	struct xfs_flock64	fl;
 	int64_t		lr;
-	off64_t		off;
-	struct stat64	stb;
+	off_t		off;
+	struct stat	stb;
 	int		v;
 	char		st[1024];
 
@@ -3828,9 +3828,9 @@ freesp_f(opnum_t opno, long r)
 		free_pathname(&f);
 		return;
 	}
-	if (fstat64(fd, &stb) < 0) {
+	if (fstat(fd, &stb) < 0) {
 		if (v)
-			printf("%d/%lld: freesp - fstat64 %s failed %d\n",
+			printf("%d/%lld: freesp - fstat %s failed %d\n",
 				procid, opno, f.path, errno);
 		free_pathname(&f);
 		close(fd);
@@ -3838,7 +3838,7 @@ freesp_f(opnum_t opno, long r)
 	}
 	inode_info(st, sizeof(st), &stb, v);
 	lr = ((int64_t)random() << 32) + random();
-	off = (off64_t)(lr % MIN(stb.st_size + (1024 * 1024), MAXFSIZE));
+	off = (off_t)(lr % MIN(stb.st_size + (1024 * 1024), MAXFSIZE));
 	off %= maxfsize;
 	fl.l_whence = SEEK_SET;
 	fl.l_start = off;
@@ -4224,9 +4224,9 @@ do_mmap(opnum_t opno, long r, int prot)
 	int		fd;
 	size_t		len;
 	int64_t		lr;
-	off64_t		off;
+	off_t		off;
 	int		flags;
-	struct stat64	stb;
+	struct stat	stb;
 	int		v;
 	char		st[1024];
 	sigjmp_buf	sigbus_jmpbuf;
@@ -4248,9 +4248,9 @@ do_mmap(opnum_t opno, long r, int prot)
 		free_pathname(&f);
 		return;
 	}
-	if (fstat64(fd, &stb) < 0) {
+	if (fstat(fd, &stb) < 0) {
 		if (v)
-			printf("%d/%lld: do_mmap - fstat64 %s failed %d\n",
+			printf("%d/%lld: do_mmap - fstat %s failed %d\n",
 			       procid, opno, f.path, errno);
 		free_pathname(&f);
 		close(fd);
@@ -4267,7 +4267,7 @@ do_mmap(opnum_t opno, long r, int prot)
 	}
 
 	lr = ((int64_t)random() << 32) + random();
-	off = (off64_t)(lr % stb.st_size);
+	off = (off_t)(lr % stb.st_size);
 	off = rounddown_64(off, sysconf(_SC_PAGE_SIZE));
 	len = (size_t)(random() % MIN(stb.st_size - off, FILELEN_MAX)) + 1;
 
@@ -4369,8 +4369,8 @@ read_f(opnum_t opno, long r)
 	int		fd;
 	size_t		len;
 	int64_t		lr;
-	off64_t		off;
-	struct stat64	stb;
+	off_t		off;
+	struct stat	stb;
 	int		v;
 	char		st[1024];
 
@@ -4391,9 +4391,9 @@ read_f(opnum_t opno, long r)
 		free_pathname(&f);
 		return;
 	}
-	if (fstat64(fd, &stb) < 0) {
+	if (fstat(fd, &stb) < 0) {
 		if (v)
-			printf("%d/%lld: read - fstat64 %s failed %d\n",
+			printf("%d/%lld: read - fstat %s failed %d\n",
 				procid, opno, f.path, errno);
 		free_pathname(&f);
 		close(fd);
@@ -4409,7 +4409,7 @@ read_f(opnum_t opno, long r)
 		return;
 	}
 	lr = ((int64_t)random() << 32) + random();
-	off = (off64_t)(lr % stb.st_size);
+	off = (off_t)(lr % stb.st_size);
 	lseek64(fd, off, SEEK_SET);
 	len = (random() % FILELEN_MAX) + 1;
 	buf = malloc(len);
@@ -4453,8 +4453,8 @@ readv_f(opnum_t opno, long r)
 	int		fd;
 	size_t		len;
 	int64_t		lr;
-	off64_t		off;
-	struct stat64	stb;
+	off_t		off;
+	struct stat	stb;
 	int		v;
 	char		st[1024];
 	struct iovec	*iov = NULL;
@@ -4480,9 +4480,9 @@ readv_f(opnum_t opno, long r)
 		free_pathname(&f);
 		return;
 	}
-	if (fstat64(fd, &stb) < 0) {
+	if (fstat(fd, &stb) < 0) {
 		if (v)
-			printf("%d/%lld: readv - fstat64 %s failed %d\n",
+			printf("%d/%lld: readv - fstat %s failed %d\n",
 				procid, opno, f.path, errno);
 		free_pathname(&f);
 		close(fd);
@@ -4498,7 +4498,7 @@ readv_f(opnum_t opno, long r)
 		return;
 	}
 	lr = ((int64_t)random() << 32) + random();
-	off = (off64_t)(lr % stb.st_size);
+	off = (off_t)(lr % stb.st_size);
 	lseek64(fd, off, SEEK_SET);
 	len = (random() % FILELEN_MAX) + 1;
 	buf = malloc(len);
@@ -4738,8 +4738,8 @@ resvsp_f(opnum_t opno, long r)
 	int		fd;
 	struct xfs_flock64	fl;
 	int64_t		lr;
-	off64_t		off;
-	struct stat64	stb;
+	off_t		off;
+	struct stat	stb;
 	int		v;
 	char		st[1024];
 
@@ -4760,9 +4760,9 @@ resvsp_f(opnum_t opno, long r)
 		free_pathname(&f);
 		return;
 	}
-	if (fstat64(fd, &stb) < 0) {
+	if (fstat(fd, &stb) < 0) {
 		if (v)
-			printf("%d/%lld: resvsp - fstat64 %s failed %d\n",
+			printf("%d/%lld: resvsp - fstat %s failed %d\n",
 				procid, opno, f.path, errno);
 		free_pathname(&f);
 		close(fd);
@@ -4770,11 +4770,11 @@ resvsp_f(opnum_t opno, long r)
 	}
 	inode_info(st, sizeof(st), &stb, v);
 	lr = ((int64_t)random() << 32) + random();
-	off = (off64_t)(lr % MIN(stb.st_size + (1024 * 1024), MAXFSIZE));
+	off = (off_t)(lr % MIN(stb.st_size + (1024 * 1024), MAXFSIZE));
 	off %= maxfsize;
 	fl.l_whence = SEEK_SET;
 	fl.l_start = off;
-	fl.l_len = (off64_t)(random() % (1024 * 1024));
+	fl.l_len = (off_t)(random() % (1024 * 1024));
 	e = xfsctl(f.path, fd, XFS_IOC_RESVSP64, &fl) < 0 ? errno : 0;
 	if (v)
 		printf("%d/%lld: xfsctl(XFS_IOC_RESVSP64) %s%s %lld %lld %d\n",
@@ -4971,7 +4971,7 @@ stat_f(opnum_t opno, long r)
 {
 	int		e;
 	pathname_t	f;
-	struct stat64	stb;
+	struct stat	stb;
 	int		v;
 
 	init_pathname(&f);
@@ -4981,7 +4981,7 @@ stat_f(opnum_t opno, long r)
 		free_pathname(&f);
 		return;
 	}
-	e = lstat64_path(&f, &stb) < 0 ? errno : 0;
+	e = lstat_path(&f, &stb) < 0 ? errno : 0;
 	check_cwd();
 	if (v)
 		printf("%d/%lld: stat %s %d\n", procid, opno, f.path, e);
@@ -5132,8 +5132,8 @@ truncate_f(opnum_t opno, long r)
 	int		e;
 	pathname_t	f;
 	int64_t		lr;
-	off64_t		off;
-	struct stat64	stb;
+	off_t		off;
+	struct stat	stb;
 	int		v;
 	char		st[1024];
 
@@ -5144,18 +5144,18 @@ truncate_f(opnum_t opno, long r)
 		free_pathname(&f);
 		return;
 	}
-	e = stat64_path(&f, &stb) < 0 ? errno : 0;
+	e = stat_path(&f, &stb) < 0 ? errno : 0;
 	check_cwd();
 	if (e > 0) {
 		if (v)
-			printf("%d/%lld: truncate - stat64 %s failed %d\n",
+			printf("%d/%lld: truncate - stat %s failed %d\n",
 				procid, opno, f.path, e);
 		free_pathname(&f);
 		return;
 	}
 	inode_info(st, sizeof(st), &stb, v);
 	lr = ((int64_t)random() << 32) + random();
-	off = (off64_t)(lr % MIN(stb.st_size + (1024 * 1024), MAXFSIZE));
+	off = (off_t)(lr % MIN(stb.st_size + (1024 * 1024), MAXFSIZE));
 	off %= maxfsize;
 	e = truncate64_path(&f, off) < 0 ? errno : 0;
 	check_cwd();
@@ -5208,8 +5208,8 @@ unresvsp_f(opnum_t opno, long r)
 	int		fd;
 	struct xfs_flock64	fl;
 	int64_t		lr;
-	off64_t		off;
-	struct stat64	stb;
+	off_t		off;
+	struct stat	stb;
 	int		v;
 	char		st[1024];
 
@@ -5230,9 +5230,9 @@ unresvsp_f(opnum_t opno, long r)
 		free_pathname(&f);
 		return;
 	}
-	if (fstat64(fd, &stb) < 0) {
+	if (fstat(fd, &stb) < 0) {
 		if (v)
-			printf("%d/%lld: unresvsp - fstat64 %s failed %d\n",
+			printf("%d/%lld: unresvsp - fstat %s failed %d\n",
 				procid, opno, f.path, errno);
 		free_pathname(&f);
 		close(fd);
@@ -5240,11 +5240,11 @@ unresvsp_f(opnum_t opno, long r)
 	}
 	inode_info(st, sizeof(st), &stb, v);
 	lr = ((int64_t)random() << 32) + random();
-	off = (off64_t)(lr % MIN(stb.st_size + (1024 * 1024), MAXFSIZE));
+	off = (off_t)(lr % MIN(stb.st_size + (1024 * 1024), MAXFSIZE));
 	off %= maxfsize;
 	fl.l_whence = SEEK_SET;
 	fl.l_start = off;
-	fl.l_len = (off64_t)(random() % (1 << 20));
+	fl.l_len = (off_t)(random() % (1 << 20));
 	e = xfsctl(f.path, fd, XFS_IOC_UNRESVSP64, &fl) < 0 ? errno : 0;
 	if (v)
 		printf("%d/%lld: xfsctl(XFS_IOC_UNRESVSP64) %s%s %lld %lld %d\n",
@@ -5280,8 +5280,8 @@ write_f(opnum_t opno, long r)
 	int		fd;
 	size_t		len;
 	int64_t		lr;
-	off64_t		off;
-	struct stat64	stb;
+	off_t		off;
+	struct stat	stb;
 	int		v;
 	char		st[1024];
 
@@ -5302,9 +5302,9 @@ write_f(opnum_t opno, long r)
 		free_pathname(&f);
 		return;
 	}
-	if (fstat64(fd, &stb) < 0) {
+	if (fstat(fd, &stb) < 0) {
 		if (v)
-			printf("%d/%lld: write - fstat64 %s failed %d\n",
+			printf("%d/%lld: write - fstat %s failed %d\n",
 				procid, opno, f.path, errno);
 		free_pathname(&f);
 		close(fd);
@@ -5312,7 +5312,7 @@ write_f(opnum_t opno, long r)
 	}
 	inode_info(st, sizeof(st), &stb, v);
 	lr = ((int64_t)random() << 32) + random();
-	off = (off64_t)(lr % MIN(stb.st_size + (1024 * 1024), MAXFSIZE));
+	off = (off_t)(lr % MIN(stb.st_size + (1024 * 1024), MAXFSIZE));
 	off %= maxfsize;
 	lseek64(fd, off, SEEK_SET);
 	len = (random() % FILELEN_MAX) + 1;
@@ -5336,8 +5336,8 @@ writev_f(opnum_t opno, long r)
 	int		fd;
 	size_t		len;
 	int64_t		lr;
-	off64_t		off;
-	struct stat64	stb;
+	off_t		off;
+	struct stat	stb;
 	int		v;
 	char		st[1024];
 	struct iovec	*iov = NULL;
@@ -5363,9 +5363,9 @@ writev_f(opnum_t opno, long r)
 		free_pathname(&f);
 		return;
 	}
-	if (fstat64(fd, &stb) < 0) {
+	if (fstat(fd, &stb) < 0) {
 		if (v)
-			printf("%d/%lld: writev - fstat64 %s failed %d\n",
+			printf("%d/%lld: writev - fstat %s failed %d\n",
 				procid, opno, f.path, errno);
 		free_pathname(&f);
 		close(fd);
@@ -5373,7 +5373,7 @@ writev_f(opnum_t opno, long r)
 	}
 	inode_info(st, sizeof(st), &stb, v);
 	lr = ((int64_t)random() << 32) + random();
-	off = (off64_t)(lr % MIN(stb.st_size + (1024 * 1024), MAXFSIZE));
+	off = (off_t)(lr % MIN(stb.st_size + (1024 * 1024), MAXFSIZE));
 	off %= maxfsize;
 	lseek64(fd, off, SEEK_SET);
 	len = (random() % FILELEN_MAX) + 1;

--- a/tests/fssum.c
+++ b/tests/fssum.c
@@ -519,9 +519,9 @@ sum(int dirfd, int level, sum_t *dircs, char *path_prefix, char *path_in)
 	int excl;
 	sum_file_data_t sum_file_data = flags[FLAG_STRUCTURE] ?
 			sum_file_data_strict : sum_file_data_permissive;
-	struct stat64 dir_st;
+	struct stat dir_st;
 
-	if (fstat64(dirfd, &dir_st)) {
+	if (fstat(dirfd, &dir_st)) {
 		perror("fstat");
 		exit(-1);
 	}
@@ -552,7 +552,7 @@ sum(int dirfd, int level, sum_t *dircs, char *path_prefix, char *path_in)
 	}
 	qsort(namelist, entries, sizeof(*namelist), namecmp);
 	for (i = 0; i < entries; ++i) {
-		struct stat64 st;
+		struct stat st;
 		sum_t cs;
 		sum_t meta;
 		char *path;
@@ -572,7 +572,7 @@ sum(int dirfd, int level, sum_t *dircs, char *path_prefix, char *path_in)
 			perror("fchdir");
 			exit(-1);
 		}
-		ret = lstat64(namelist[i], &st);
+		ret = lstat(namelist[i], &st);
 		if (ret) {
 			fprintf(stderr, "stat failed for %s/%s: %m\n",
 				path_prefix, path);


### PR DESCRIPTION
```
the *64 interfaces, such as fstat64, off64_t, etc, are legacy interfaces       
created at a time when 64-bit file support was still new. they are             
generally exposed when defining a macro named _LARGEFILE64_SOURCE, as          
e.g. the glibc docs[0] say.                                                    
                                                                               
the modern way to utilise largefile support, is to continue to use the         
regular interfaces (off_t, fstat, ..), and define _FILE_OFFSET_BITS=64.        
                                                                               
we already use the autoconf macro AC_SYS_LARGEFILE[1] which arranges this      
and sets this macro for us. therefore, we can utilise the non-64 names         
without fear of breaking on 32-bit systems.                                    
                                                                               
this fixes the build against musl libc, ever since musl dropped the            
*64 compat from interfaces by default[2] just for _GNU_SOURCE, unless          
_LARGEFILE64_SOURCE is defined. however, there are plans for a future          
removal of the whole *64 header api, and that workaround (adding another       
define) might cease to exist.                                                  
                                                                               
so, rename all *64 api use to the regular non-suffixed names. for              
consistency, rename the internal functions that were *64 named                 
(lstat64_path, ..) too.                                                        
                                                                               
this should have no regressions on any platform.          

[0]: https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html#index-_005fLARGEFILE64_005fSOURCE
[1]: https://www.gnu.org/software/autoconf/manual/autoconf-2.67/html_node/System-Services.html
[2]: https://github.com/bminor/musl/commit/25e6fee27f4a293728dd15b659170e7b9c7db9bc
```