### PR TITLE
btrfs-progs: check: add check for metadata level mismatch

### DIFF
--- a/check/mode-original.h
+++ b/check/mode-original.h
@@ -90,6 +90,7 @@ struct extent_record {
 	u64 info_objectid;
 	u32 num_duplicates;
 	u8 info_level;
+	u8 level;
 	unsigned int flag_block_full_backref:2;
 	unsigned int found_rec:1;
 	unsigned int content_checked:1;


### PR DESCRIPTION
For a skinny metadata item in the extent tree, the key offset represents the level of the tree it points to. This adds a check that these values match, as otherwise it can cause a volume to go readonly when deleting a large number of inodes.

See https://github.com/maharmstone/ntfs2btrfs/issues/51