### PR TITLE
mkfs: make --quiet silence the 5.15 default change NOTE

### DIFF
--- a/mkfs/main.c
+++ b/mkfs/main.c
@@ -1541,12 +1541,14 @@ int BOX_MAIN(mkfs)(int argc, char **argv)
 	    btrfs_bg_type_to_tolerated_failures(data_profile))
 		warning("metadata has lower redundancy than data!\n");
 
-	printf("NOTE: several default settings have changed in version 5.15, please make sure\n");
-	printf("      this does not affect your deployments:\n");
-	printf("      - DUP for metadata (-m dup)\n");
-	printf("      - enabled no-holes (-O no-holes)\n");
-	printf("      - enabled free-space-tree (-R free-space-tree)\n");
-	printf("\n");
+	if (bconf.verbose) {
+		printf("NOTE: several default settings have changed in version 5.15, please make sure\n");
+		printf("      this does not affect your deployments:\n");
+		printf("      - DUP for metadata (-m dup)\n");
+		printf("      - enabled no-holes (-O no-holes)\n");
+		printf("      - enabled free-space-tree (-R free-space-tree)\n");
+		printf("\n");
+	}
 
 	mkfs_cfg.label = label;
 	memcpy(mkfs_cfg.fs_uuid, fs_uuid, sizeof(mkfs_cfg.fs_uuid));


### PR DESCRIPTION
mkfs.btrfs help message for --quiet is 'no message except errors' so we probably ought to silence this as well in the quiet case.

-----

It's easy enough to redirect stdout to /dev/null but might as well have --quiet do what it says.
(feel free to consider this a non-issue if this is on purpose, but there wasn't any other issue or PR about this -- I'll admit I didn't check the ML)

Thanks!