### PR TITLE
kernel-shared/uapi/btrfs.h: fix BTRFS_IOC_SCAN_DEV

### DIFF
--- a/kernel-shared/uapi/btrfs.h
+++ b/kernel-shared/uapi/btrfs.h
@@ -1171,7 +1171,7 @@ enum btrfs_err_code {
 				   struct btrfs_ioctl_vol_args)
 #define BTRFS_IOC_RESIZE _IOW(BTRFS_IOCTL_MAGIC, 3, \
 				   struct btrfs_ioctl_vol_args)
-#define BTRFS_IOC_SCAN_DEV _IOW(BTRFS_IOCTL_MAGIC, 5, \
+#define BTRFS_IOC_SCAN_DEV _IOW(BTRFS_IOCTL_MAGIC, 4, \
 				   struct btrfs_ioctl_vol_args)
 #define BTRFS_IOC_FORGET_DEV _IOW(BTRFS_IOCTL_MAGIC, 5, \
 				   struct btrfs_ioctl_vol_args)


### PR DESCRIPTION
Without the change `BTRFS_IOC_SCAN_DEV` aliased with `BTRFS_IOC_FORGET_DEV`. It's a regression introduced in fcd9142b6 "btrfs-progs: docs: formatting, fixups, updates".

It manifests as a sudden device disappearance when device is scanned:

    machine # [    4.095032] Btrfs loaded, crc32c=crc32c-intel, zoned=no, fsverity=no
    machine # ERROR: device scan failed on '/dev/vdb': No such file or directory
    machine # ERROR: device scan failed on '/dev/vdc': No such file or directory
    (finished: must succeed: mkfs.btrfs -d raid0 /dev/vdb /dev/vdc, in 10.31 seconds)

Reported-by: Atemu <atemu.main@gmail.com>
Bug: https://github.com/NixOS/nixpkgs/issues/265668