### PR TITLE
Fix -Walloc-size

### DIFF
--- a/cmds/qgroup.c
+++ b/cmds/qgroup.c
@@ -1641,7 +1641,7 @@ static int qgroup_inherit_realloc(struct btrfs_qgroup_inherit **inherit, int n,
 			 (*inherit)->num_excl_copies;
 	}
 
-	out = calloc(sizeof(*out) + sizeof(out->qgroups[0]) * (nitems + n), 1);
+	out = calloc(1, sizeof(*out) + sizeof(out->qgroups[0]) * (nitems + n));
 	if (out == NULL) {
 		error_msg(ERROR_MSG_MEMORY, NULL);
 		return -ENOMEM;

--- a/common/utils.c
+++ b/common/utils.c
@@ -980,7 +980,7 @@ void bconf_add_param(const char *key, const char *value)
 {
 	struct config_param *param;
 
-	param = calloc(sizeof(*param), 1);
+	param = calloc(1, sizeof(*param));
 	if (!param)
 		return;
 	param->key = strdup(key);


### PR DESCRIPTION
GCC 14 introduces a new -Walloc-size included in -Wextra which gives:
```
common/utils.c:983:15: warning: allocation of insufficient size ‘1’ for type ‘struct config_param’ with size ‘32’ [-Walloc-size]
cmds/qgroup.c:1644:13: warning: allocation of insufficient size ‘1’ for type ‘struct btrfs_qgroup_inherit’ with size ‘72’ [-Walloc-size]
```

The calloc prototype is:
```
void *calloc(size_t nmemb, size_t size);
```

So, just swap the number of members and size arguments to match the prototype, as we're initialising 1 struct of size `sizeof(struct ...)`. GCC then sees we're not doing anything wrong.