### PR TITLE
Fix reporting of scrub limits on multi-device filesystems

### DIFF
--- a/cmds/scrub.c
+++ b/cmds/scrub.c
@@ -387,7 +387,7 @@ static void print_fs_stat(struct scrub_fs_stat *fs_stat, int raw, u64 bytes_tota
 		 * Limit for the whole filesystem stats does not make sense,
 		 * but if there's any device with a limit then print it.
 		 */
-		if (nr_devices != 1)
+		if (nr_devices != 1 && limit)
 			limit = 1;
 		print_scrub_summary(&fs_stat->p, &fs_stat->s, bytes_total, limit);
 	}

--- a/cmds/scrub.c
+++ b/cmds/scrub.c
@@ -1634,8 +1634,11 @@ static int scrub_start(const struct cmd_struct *cmd, int argc, char **argv,
 			struct btrfs_scrub_progress *cur_progress =
 						&sp[i].scrub_args.progress;
 
-			/* Save last limit only, works for single device filesystem. */
-			limit = sp[i].limit;
+			/* On a multi-device filesystem, keep the lowest limit only. */
+			if (!limit || (sp[i].limit && sp[i].limit < limit)) {
+				limit = sp[i].limit;
+			}
+
 			if (do_stats_per_dev) {
 				print_scrub_dev(&di_args[i],
 						cur_progress,

--- a/cmds/scrub.c
+++ b/cmds/scrub.c
@@ -1947,8 +1947,11 @@ static int cmd_scrub_status(const struct cmd_struct *cmd, int argc, char **argv)
 		init_fs_stat(&fs_stat);
 		fs_stat.s.in_progress = in_progress;
 		for (i = 0; i < fi_args.num_devices; ++i) {
-			/* Save the last limit only, works for a single device filesystem. */
-			limit = read_scrub_device_limit(fdmnt, di_args[i].devid);
+			/* On a multi-device filesystem, keep the lowest limit only. */
+			u64 this_limit = read_scrub_device_limit(fdmnt, di_args[i].devid);
+			if (!limit || (this_limit && this_limit < limit)) {
+				limit = this_limit;
+			}
 
 			last_scrub = last_dev_scrub(past_scrubs,
 							di_args[i].devid);


### PR DESCRIPTION
On multi-device filesystems, scrub status should report "some limits set" if at least one device has a scrub limit set.

However, with btrfs-progs 6.6.3, this was being reported regardless of whether any limit actually being set:

    # sudo btrfs scrub limit /more/butter
    UUID: 989129d9-c96f-4d52-9d68-cbb6d9b2c499
    Id  Limit       Path
    --  -----  ---------
     1      -  /dev/sdc1
     2      -  /dev/sdd1

    # sudo btrfs scrub status /more/butter/
    UUID:             989129d9-c96f-4d52-9d68-cbb6d9b2c499
    Scrub started:    Mon Jan 15 02:00:30 2024
    Status:           running
    Duration:         6:23:19
    Time left:        0:49:08
    ETA:              Mon Jan 15 09:12:57 2024
    Total to scrub:   9.83TiB
    Bytes scrubbed:   8.72TiB  (88.64%)
    Rate:             397.47MiB/s (some device limits set)
    Error summary:    no errors found
    
Fixes: #727 