### PR TITLE
libbtrfsutil: add btrfs_util_get_label

### DIFF
--- a/libbtrfsutil/README.md
+++ b/libbtrfsutil/README.md
@@ -479,6 +479,7 @@ everywhere. The following checklist should help to make sure nothing is missing:
 ### API summary
 
 * filesystem
+  * get_label
   * sync
   * wait for sync
 * subvolume

--- a/libbtrfsutil/btrfsutil.h
+++ b/libbtrfsutil/btrfsutil.h
@@ -67,6 +67,7 @@ enum btrfs_util_error {
 	BTRFS_UTIL_ERROR_GET_SUBVOL_ROOTREF_FAILED,
 	BTRFS_UTIL_ERROR_INO_LOOKUP_USER_FAILED,
 	BTRFS_UTIL_ERROR_FS_INFO_FAILED,
+	BTRFS_UTIL_ERROR_FS_GET_LABEL_FAILED,
 };
 
 /**
@@ -77,6 +78,24 @@ enum btrfs_util_error {
  * Return: Error description.
  */
 const char *btrfs_util_strerror(enum btrfs_util_error err);
+
+/**
+ * btrfs_util_get_label() - Get the filesystem label for a
+ * filesystem.
+ * @path: Path on a Btrfs filesystem.
+ * @label: Returned filesytem label.
+ *
+ * Return: %BTRFS_UTIL_OK on success, non-zero error code on failure.
+ */
+enum btrfs_util_error btrfs_util_get_label(const char *path,
+					   char **label);
+
+/**
+ * btrfs_util_get_label_fd() - See
+ * btrfs_util_get_label().
+ */
+enum btrfs_util_error btrfs_util_get_label_fd(int fd,
+					      char **label);
 
 /**
  * btrfs_util_sync() - Force a sync on a specific Btrfs filesystem.

--- a/libbtrfsutil/errors.c
+++ b/libbtrfsutil/errors.c
@@ -53,6 +53,8 @@ static const char * const error_messages[] = {
 		"Could not resolve subvolume path with BTRFS_IOC_INO_LOOKUP_USER",
 	[BTRFS_UTIL_ERROR_FS_INFO_FAILED] =
 		"Could not get filesystem information",
+	[BTRFS_UTIL_ERROR_FS_GET_LABEL_FAILED] =
+		"Could not get filesystem label",
 };
 
 PUBLIC const char *btrfs_util_strerror(enum btrfs_util_error err)

--- a/libbtrfsutil/libbtrfsutil.sym
+++ b/libbtrfsutil/libbtrfsutil.sym
@@ -16,6 +16,8 @@ global:
 	btrfs_util_destroy_subvolume_iterator;
 	btrfs_util_get_default_subvolume;
 	btrfs_util_get_default_subvolume_fd;
+	btrfs_util_get_label;
+	btrfs_util_get_label_fd;
 	btrfs_util_get_subvolume_read_only;
 	btrfs_util_get_subvolume_read_only_fd;
 	btrfs_util_is_subvolume;

--- a/libbtrfsutil/python/btrfsutilpy.h
+++ b/libbtrfsutil/python/btrfsutilpy.h
@@ -63,6 +63,7 @@ void SetFromBtrfsUtilErrorWithPaths(enum btrfs_util_error err,
 				    struct path_arg *path1,
 				    struct path_arg *path2);
 
+PyObject *filesystem_get_label(PyObject *self, PyObject *args, PyObject *kwds);
 PyObject *filesystem_sync(PyObject *self, PyObject *args, PyObject *kwds);
 PyObject *start_sync(PyObject *self, PyObject *args, PyObject *kwds);
 PyObject *wait_sync(PyObject *self, PyObject *args, PyObject *kwds);

--- a/libbtrfsutil/python/filesystem.c
+++ b/libbtrfsutil/python/filesystem.c
@@ -19,6 +19,31 @@
 
 #include "btrfsutilpy.h"
 
+PyObject *filesystem_get_label(PyObject *self, PyObject *args, PyObject *kwds)
+{
+	static char *keywords[] = {"path", NULL};
+	struct path_arg path = {.allow_fd = true};
+	enum btrfs_util_error err;
+	char *label;
+
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "O&:get_label", keywords,
+					 &path_converter, &path))
+		return NULL;
+
+	if (path.path)
+		err = btrfs_util_get_label(path.path, &label);
+	else
+		err = btrfs_util_get_label_fd(path.fd, &label);
+	if (err) {
+		SetFromBtrfsUtilErrorWithPath(err, &path);
+		path_cleanup(&path);
+		return NULL;
+	}
+
+	path_cleanup(&path);
+	return PyUnicode_FromString(label);
+}
+
 PyObject *filesystem_sync(PyObject *self, PyObject *args, PyObject *kwds)
 {
 	static char *keywords[] = {"path", NULL};

--- a/libbtrfsutil/python/module.c
+++ b/libbtrfsutil/python/module.c
@@ -155,6 +155,12 @@ void path_cleanup(struct path_arg *path)
 }
 
 static PyMethodDef btrfsutil_methods[] = {
+	{"get_label", (PyCFunction)filesystem_get_label,
+	 METH_VARARGS | METH_KEYWORDS,
+	 "get_label(path)\n\n"
+	 "Get the filesystem label.\n\n"
+	 "Arguments:\n"
+	 "path -- string, bytes, path-like object, or open file descriptor"},
 	{"sync", (PyCFunction)filesystem_sync,
 	 METH_VARARGS | METH_KEYWORDS,
 	 "sync(path)\n\n"

--- a/libbtrfsutil/python/tests/test_filesystem.py
+++ b/libbtrfsutil/python/tests/test_filesystem.py
@@ -71,3 +71,7 @@ class TestFilesystem(BtrfsTestCase):
                 new_generation = self.super_generation()
                 self.assertGreater(new_generation, old_generation)
                 old_generation = new_generation
+
+    def test_get_label(self):
+        label = btrfsutil.get_label(self.mountpoint)
+        self.assertIsNotNone(label)


### PR DESCRIPTION
Extend libbtrfs with a method to obtain to btrfs filesystem label.

---

Hey, this is a first PR of hopefully more to come. I'm looking at extending libbtrfsutil as we intend to use it in [libblockdev](https://github.com/storaged-project/libblockdev/pull/999) to avoid parsing `btrfs` CLI output.

This is just a simple starter PR, some more interesting such as volume information (devices, RAID data, etc. basically btrfs filesystem show), creating a volume and adding/removing devices.  And of course, `btrfs_util_set_label` happy to include that in this PR if required. 