### PR TITLE
btrfs-progs: hunt down the stray fd close causing race with udev scan

### DIFF
--- a/.github/workflows/artifacts-static-build.yml
+++ b/.github/workflows/artifacts-static-build.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: sudo apt-get install -y pkg-config gcc liblzo2-dev libzstd-dev libblkid-dev uuid-dev zlib1g-dev libext2fs-dev e2fsprogs libudev-dev python3-sphinx libaio-dev liburing-dev
       - name: Configure
         run: ./autogen.sh && ./configure --disable-documentation
@@ -27,22 +27,22 @@ jobs:
           sha256sum btrfs.static | tee btrfs.static.sha256
           sha256sum btrfs.box.static | tee btrfs.box.static.sha256
       - name: Save artifacts - btrfs.static
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: btrfs.static
           path: btrfs.static
       - name: Save artifacts - btrfs.static.sha256
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: btrfs.static.sha256
           path: btrfs.static.sha256
       - name: Save artifacts - btrfs.box.static
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: btrfs.box.static
           path: btrfs.box.static
       - name: Save artifacts - btrfs.box.static.sha256
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: btrfs.box.static.sha256
           path: btrfs.box.static.sha256

--- a/.github/workflows/ci-build-test-fast.yml
+++ b/.github/workflows/ci-build-test-fast.yml
@@ -82,6 +82,6 @@ jobs:
 #     name: CI Tumbleweed (OpenSSL)
 #     runs-on: ubuntu-latest
 #     steps:
-#       - uses: actions/checkout@v3
+#       - uses: actions/checkout@v4
 #       - name: CI Tumbleweed (OpenSSL)
 #         run: sudo docker run kdave/ci-opensuse-tumbleweed-x86_64 ./test-build $GITHUB_REF_NAME --disable-documentation --with-crypto=openssl

--- a/.github/workflows/ci-build-test-fast.yml
+++ b/.github/workflows/ci-build-test-fast.yml
@@ -1,0 +1,87 @@
+# Backward compatibility build tests on various distros
+#
+# - all compatibility docker image build tests (no local build)
+# - same as ci-build-test.yml but does not rebuild the docker images here but
+#   pulls them from docker hub, which is faster overall but may get out of sync
+
+name: CI image tests fast
+run-name: CI image tests fast
+on:
+  push:
+    branches:
+      - "ci/**"
+      - devel
+jobs:
+  check-centos7:
+    name: CI Centos 7
+    runs-on: ubuntu-latest
+    steps:
+      - name: CI Centos7
+        run: sudo docker run kdave/ci-centos-7-x86_64 ./test-build $GITHUB_REF_NAME --disable-documentation --disable-libudev
+  check-centos8:
+    name: CI Centos 8
+    runs-on: ubuntu-latest
+    steps:
+      - name: CI Centos8
+        run: sudo docker run kdave/ci-centos-8-x86_64 ./test-build $GITHUB_REF_NAME --disable-documentation --disable-zoned --disable-libudev
+  check-leap153:
+    name: CI Leap 15.3
+    runs-on: ubuntu-latest
+    steps:
+      - name: CI Leap 15.3
+        run: sudo docker run kdave/ci-opensuse-leap-15.3-x86_64 ./test-build $GITHUB_REF_NAME --disable-documentation --disable-zoned
+  check-leap154:
+    name: CI Leap 15.4
+    runs-on: ubuntu-latest
+    steps:
+      - name: CI Leap 15.4
+        run: sudo docker run kdave/ci-opensuse-leap-15.4-x86_64 ./test-build $GITHUB_REF_NAME --disable-documentation --disable-zoned
+  check-musl:
+    name: CI Musl
+    runs-on: ubuntu-latest
+    steps:
+      - name: CI Musl
+        run: sudo docker run kdave/ci-musl-x86_64 ./test-build $GITHUB_REF_NAME --disable-documentation --disable-backtrace --disable-libudev
+  check-musl-32bit:
+    name: CI Musl (32bit)
+    runs-on: ubuntu-latest
+    steps:
+      - name: CI Musl (32bit)
+        run: sudo docker run kdave/ci-musl-i386 ./test-build $GITHUB_REF_NAME --disable-documentation --disable-backtrace --disable-libudev
+  check-tumbleweed:
+    name: CI Tumbleweed
+    runs-on: ubuntu-latest
+    steps:
+      - name: CI Tumbleweed
+        run: sudo docker run kdave/ci-opensuse-tumbleweed-x86_64 ./test-build $GITHUB_REF_NAME --disable-documentation
+  check-tumbleweed-libgcrypt:
+    name: CI Tumbleweed (libgcrypt)
+    runs-on: ubuntu-latest
+    steps:
+      - name: CI Tumbleweed (libgcrypt)
+        run: sudo docker run kdave/ci-opensuse-tumbleweed-x86_64 ./test-build $GITHUB_REF_NAME --disable-documentation --with-crypto=libgcrypt
+  check-tumbleweed-libsodium:
+    name: CI Tumbleweed (libsodium)
+    runs-on: ubuntu-latest
+    steps:
+      - name: CI Tumbleweed (libsodium)
+        run: sudo docker run kdave/ci-opensuse-tumbleweed-x86_64 ./test-build $GITHUB_REF_NAME --disable-documentation --with-crypto=libsodium
+  check-tumbleweed-libkcapi:
+    name: CI Tumbleweed (libkcapi)
+    runs-on: ubuntu-latest
+    steps:
+      - name: CI Tumbleweed (libkcapi)
+        run: sudo docker run kdave/ci-opensuse-tumbleweed-x86_64 ./test-build $GITHUB_REF_NAME --disable-documentation --with-crypto=libkcapi
+  check-tumbleweed-botan:
+    name: CI Tumbleweed (Botan)
+    runs-on: ubuntu-latest
+    steps:
+      - name: CI Tumbleweed (Botan)
+        run: sudo docker run kdave/ci-opensuse-tumbleweed-x86_64 ./test-build $GITHUB_REF_NAME --disable-documentation --with-crypto=botan
+#   check-tumbleweed-openssl:
+#     name: CI Tumbleweed (OpenSSL)
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v3
+#       - name: CI Tumbleweed (OpenSSL)
+#         run: sudo docker run kdave/ci-opensuse-tumbleweed-x86_64 ./test-build $GITHUB_REF_NAME --disable-documentation --with-crypto=openssl

--- a/.github/workflows/ci-build-test.yml
+++ b/.github/workflows/ci-build-test.yml
@@ -14,83 +14,83 @@ jobs:
     name: CI Centos 7
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: CI Centos7
         run: ci/ci-build-centos7
   check-centos8:
     name: CI Centos 8
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: CI Centos8
         run: ci/ci-build-centos8
   check-leap153:
     name: CI Leap 15.3
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: CI Leap 15.3
         run: ci/ci-build-leap153
   check-leap154:
     name: CI Leap 15.4
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: CI Leap 15.4
         run: ci/ci-build-leap154
   check-musl:
     name: CI Musl
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: CI Musl
         run: ci/ci-build-musl
   check-musl-32bit:
     name: CI Musl (32bit)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: CI Musl (32bit)
         run: ci/ci-build-musl-i386
   check-tumbleweed:
     name: CI Tumbleweed
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: CI Tumbleweed
         run: ci/ci-build-tumbleweed
   check-tumbleweed-libgcrypt:
     name: CI Tumbleweed (libgcrypt)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: CI Tumbleweed (libgcrypt)
         run: ci/ci-build-tumbleweed HEAD --with-crypto=libgcrypt
   check-tumbleweed-libsodium:
     name: CI Tumbleweed (libsodium)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: CI Tumbleweed (libsodium)
         run: ci/ci-build-tumbleweed HEAD --with-crypto=libsodium
   check-tumbleweed-libkcapi:
     name: CI Tumbleweed (libkcapi)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: CI Tumbleweed (libkcapi)
         run: ci/ci-build-tumbleweed HEAD --with-crypto=libkcapi
   check-tumbleweed-botan:
     name: CI Tumbleweed (Botan)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: CI Tumbleweed (Botan)
         run: ci/ci-build-tumbleweed HEAD --with-crypto=botan
 #   check-tumbleweed-openssl:
 #     name: CI Tumbleweed (OpenSSL)
 #     runs-on: ubuntu-latest
 #     steps:
-#       - uses: actions/checkout@v3
+#       - uses: actions/checkout@v4
 #       - name: CI Tumbleweed (OpenSSL)
 #         run: ci/ci-build-tumbleweed HEAD --with-crypto=openssl

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: uname -a
       - run: sudo modprobe btrfs
       - run: sudo apt-get install -y pkg-config gcc liblzo2-dev libzstd-dev libblkid-dev uuid-dev zlib1g-dev libext2fs-dev e2fsprogs libudev-dev python3-sphinx libaio-dev liburing-dev attr jq lcov
@@ -46,12 +46,12 @@ jobs:
           lcov -c -d . -o lcov-info
           genhtml -o lcov-out lcov-info
       - name: Save lcov results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: lcov-out
           path: lcov-out
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ github.workspace }}/lcov-info

--- a/.github/workflows/devel.yml
+++ b/.github/workflows/devel.yml
@@ -18,7 +18,7 @@ jobs:
         compiler: [ gcc, clang ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: sudo modprobe btrfs
       - run: sudo apt-get install -y pkg-config gcc liblzo2-dev libzstd-dev libblkid-dev uuid-dev zlib1g-dev libext2fs-dev e2fsprogs libudev-dev python3-sphinx sphinx-rtd-theme-common python3-sphinx-rtd-theme
       - name: Configure
@@ -42,7 +42,7 @@ jobs:
         compiler: [ gcc, clang ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: sudo modprobe btrfs
       - run: sudo apt-get install -y pkg-config gcc liblzo2-dev libzstd-dev libblkid-dev uuid-dev zlib1g-dev libext2fs-dev e2fsprogs libudev-dev libaio-dev liburing-dev attr jq
       - name: Configure
@@ -67,7 +67,7 @@ jobs:
     name: Test mkfs.btrfs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: sudo modprobe btrfs
       - run: sudo apt-get install -y pkg-config gcc liblzo2-dev libzstd-dev libblkid-dev uuid-dev zlib1g-dev libext2fs-dev e2fsprogs libudev-dev libaio-dev liburing-dev attr jq
       - name: Configure
@@ -80,7 +80,7 @@ jobs:
     name: Test btrfs check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: sudo modprobe btrfs
       - run: sudo apt-get install -y pkg-config gcc liblzo2-dev libzstd-dev libblkid-dev uuid-dev zlib1g-dev libext2fs-dev e2fsprogs libudev-dev libaio-dev liburing-dev attr jq
       - name: Configure
@@ -95,7 +95,7 @@ jobs:
     name: Test misc
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: sudo modprobe btrfs
       - run: sudo apt-get install -y pkg-config gcc liblzo2-dev libzstd-dev libblkid-dev uuid-dev zlib1g-dev libext2fs-dev e2fsprogs libudev-dev libaio-dev liburing-dev attr jq
       - name: Configure
@@ -108,7 +108,7 @@ jobs:
     name: Test btrfs-convert
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: sudo modprobe btrfs
       - run: sudo apt-get install -y pkg-config gcc liblzo2-dev libzstd-dev libblkid-dev uuid-dev zlib1g-dev libext2fs-dev e2fsprogs libudev-dev libaio-dev liburing-dev attr jq
       - name: Configure
@@ -121,7 +121,7 @@ jobs:
     name: Test cli, fuzz
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: sudo modprobe btrfs
       - run: sudo apt-get install -y pkg-config gcc liblzo2-dev libzstd-dev libblkid-dev uuid-dev zlib1g-dev libext2fs-dev e2fsprogs libudev-dev libaio-dev liburing-dev attr jq
       - name: Configure

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: uname -a
       - run: sudo modprobe btrfs
       - run: sudo apt-get install -y pkg-config gcc liblzo2-dev libzstd-dev libblkid-dev uuid-dev zlib1g-dev libext2fs-dev e2fsprogs libudev-dev python3-sphinx libaio-dev liburing-dev attr jq

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: uname -a
       - run: sudo modprobe btrfs
       - run: cat /proc/filesystems

--- a/ci/ci-build-leap153
+++ b/ci/ci-build-leap153
@@ -31,4 +31,4 @@ gzip --force --best devel.tar
 cd "$CIIMAGEDIR"
 cp "$SOURCEDIR/devel.tar.gz" .
 ./docker-build
-./docker-run -- ./test-build devel --disable-documentation "$@"
+./docker-run -- ./test-build devel --disable-documentation --disable-zoned "$@"

--- a/ci/ci-build-leap154
+++ b/ci/ci-build-leap154
@@ -31,4 +31,4 @@ gzip --force --best devel.tar
 cd "$CIIMAGEDIR"
 cp "$SOURCEDIR/devel.tar.gz" .
 ./docker-build
-./docker-run -- ./test-build devel --disable-documentation "$@"
+./docker-run -- ./test-build devel --disable-documentation --disable-zoned "$@"

--- a/ci/images/ci-centos-7-x86_64/Dockerfile
+++ b/ci/images/ci-centos-7-x86_64/Dockerfile
@@ -29,7 +29,7 @@ COPY ./test-build .
 COPY ./run-tests .
 COPY ./devel.tar.gz .
 
-CMD ./test-build devel --disable-documentation
+CMD ./test-build devel --disable-documentation --disable-libudev
 
 # Continue with:
 # cd /tmp

--- a/ci/images/ci-centos-7-x86_64/test-build
+++ b/ci/images/ci-centos-7-x86_64/test-build
@@ -3,8 +3,9 @@
 
 urlbase="https://github.com/kdave/btrfs-progs/archive"
 branch=${1:-devel}
-fname="${branch}.tar.gz"
-url="${urlbase}/${fname}"
+fnbase="${branch/\//-}"
+fname="${fnbase}.tar.gz"
+url="${urlbase}/${branch}.tar.gz"
 
 shift
 
@@ -13,10 +14,10 @@ cd /tmp
 if [ -f "$fname" -a -s "$fname" ]; then
 	echo "Found local file $fname, not downloading"
 else
-	echo "Missing or empty tar, downloading devel branch from git"
+	echo "Missing or empty tar, downloading branch $branch from git"
 	rm -- "$fname"
 	wget "$url" -O "$fname"
 fi
 tar xf "$fname"
-cd "btrfs-progs-$branch"
+cd "btrfs-progs-$fnbase"
 ci/build-default "$@"

--- a/ci/images/ci-centos-8-x86_64/Dockerfile
+++ b/ci/images/ci-centos-8-x86_64/Dockerfile
@@ -32,7 +32,7 @@ COPY ./test-build .
 COPY ./run-tests .
 COPY ./devel.tar.gz .
 
-CMD ./test-build devel --disable-documentation --disable-zoned
+CMD ./test-build devel --disable-documentation --disable-libudev --disable-zoned
 
 # Continue with:
 # cd /tmp

--- a/ci/images/ci-centos-8-x86_64/test-build
+++ b/ci/images/ci-centos-8-x86_64/test-build
@@ -3,8 +3,9 @@
 
 urlbase="https://github.com/kdave/btrfs-progs/archive"
 branch=${1:-devel}
-fname="${branch}.tar.gz"
-url="${urlbase}/${fname}"
+fnbase="${branch/\//-}"
+fname="${fnbase}.tar.gz"
+url="${urlbase}/${branch}.tar.gz"
 
 shift
 
@@ -13,10 +14,10 @@ cd /tmp
 if [ -f "$fname" -a -s "$fname" ]; then
 	echo "Found local file $fname, not downloading"
 else
-	echo "Missing or empty tar, downloading devel branch from git"
+	echo "Missing or empty tar, downloading branch $branch from git"
 	rm -- "$fname"
 	wget "$url" -O "$fname"
 fi
 tar xf "$fname"
-cd "btrfs-progs-$branch"
+cd "btrfs-progs-$fnbase"
 ci/build-default "$@"

--- a/ci/images/ci-musl-i386/docker-build
+++ b/ci/images/ci-musl-i386/docker-build
@@ -8,4 +8,4 @@ image=$(basename `pwd` | tr '[A-Z]' '[a-z]')
 # Make sure the file exists as it's required but can be empty. In that case
 # it's downloaded when ./test-build is executed
 touch devel.tar.gz
-docker buildx build --platform linux/386 -t "$prefix/$image" .
+docker build --platform linux/386 -t "$prefix/$image" .

--- a/ci/images/ci-musl-i386/test-build
+++ b/ci/images/ci-musl-i386/test-build
@@ -3,8 +3,9 @@
 
 urlbase="https://github.com/kdave/btrfs-progs/archive"
 branch=${1:-devel}
-fname="${branch}.tar.gz"
-url="${urlbase}/${fname}"
+fnbase="${branch/\//-}"
+fname="${fnbase}.tar.gz"
+url="${urlbase}/${branch}.tar.gz"
 
 shift
 
@@ -13,10 +14,10 @@ cd /tmp
 if [ -f "$fname" -a -s "$fname" ]; then
 	echo "Found local file $fname, not downloading"
 else
-	echo "Missing or empty tar, downloading devel branch from git"
+	echo "Missing or empty tar, downloading branch $branch from git"
 	rm -- "$fname"
 	wget "$url" -O "$fname"
 fi
 tar xf "$fname"
-cd "btrfs-progs-$branch"
+cd "btrfs-progs-$fnbase"
 ci/build-default "$@"

--- a/ci/images/ci-musl-x86_64/test-build
+++ b/ci/images/ci-musl-x86_64/test-build
@@ -3,8 +3,9 @@
 
 urlbase="https://github.com/kdave/btrfs-progs/archive"
 branch=${1:-devel}
-fname="${branch}.tar.gz"
-url="${urlbase}/${fname}"
+fnbase="${branch/\//-}"
+fname="${fnbase}.tar.gz"
+url="${urlbase}/${branch}.tar.gz"
 
 shift
 
@@ -13,10 +14,10 @@ cd /tmp
 if [ -f "$fname" -a -s "$fname" ]; then
 	echo "Found local file $fname, not downloading"
 else
-	echo "Missing or empty tar, downloading devel branch from git"
+	echo "Missing or empty tar, downloading branch $branch from git"
 	rm -- "$fname"
 	wget "$url" -O "$fname"
 fi
 tar xf "$fname"
-cd "btrfs-progs-$branch"
+cd "btrfs-progs-$fnbase"
 ci/build-default "$@"

--- a/ci/images/ci-openSUSE-Leap-15.3-x86_64/test-build
+++ b/ci/images/ci-openSUSE-Leap-15.3-x86_64/test-build
@@ -3,8 +3,9 @@
 
 urlbase="https://github.com/kdave/btrfs-progs/archive"
 branch=${1:-devel}
-fname="${branch}.tar.gz"
-url="${urlbase}/${fname}"
+fnbase="${branch/\//-}"
+fname="${fnbase}.tar.gz"
+url="${urlbase}/${branch}.tar.gz"
 
 shift
 
@@ -13,10 +14,10 @@ cd /tmp
 if [ -f "$fname" -a -s "$fname" ]; then
 	echo "Found local file $fname, not downloading"
 else
-	echo "Missing or empty tar, downloading devel branch from git"
+	echo "Missing or empty tar, downloading branch $branch from git"
 	rm -- "$fname"
 	wget "$url" -O "$fname"
 fi
 tar xf "$fname"
-cd "btrfs-progs-$branch"
+cd "btrfs-progs-$fnbase"
 ci/build-default "$@"

--- a/ci/images/ci-openSUSE-Leap-15.4-x86_64/test-build
+++ b/ci/images/ci-openSUSE-Leap-15.4-x86_64/test-build
@@ -3,8 +3,9 @@
 
 urlbase="https://github.com/kdave/btrfs-progs/archive"
 branch=${1:-devel}
-fname="${branch}.tar.gz"
-url="${urlbase}/${fname}"
+fnbase="${branch/\//-}"
+fname="${fnbase}.tar.gz"
+url="${urlbase}/${branch}.tar.gz"
 
 shift
 
@@ -13,10 +14,10 @@ cd /tmp
 if [ -f "$fname" -a -s "$fname" ]; then
 	echo "Found local file $fname, not downloading"
 else
-	echo "Missing or empty tar, downloading devel branch from git"
+	echo "Missing or empty tar, downloading branch $branch from git"
 	rm -- "$fname"
 	wget "$url" -O "$fname"
 fi
 tar xf "$fname"
-cd "btrfs-progs-$branch"
+cd "btrfs-progs-$fnbase"
 ci/build-default "$@"

--- a/ci/images/ci-openSUSE-tumbleweed-x86_64/test-build
+++ b/ci/images/ci-openSUSE-tumbleweed-x86_64/test-build
@@ -3,8 +3,9 @@
 
 urlbase="https://github.com/kdave/btrfs-progs/archive"
 branch=${1:-devel}
-fname="${branch}.tar.gz"
-url="${urlbase}/${fname}"
+fnbase="${branch/\//-}"
+fname="${fnbase}.tar.gz"
+url="${urlbase}/${branch}.tar.gz"
 
 shift
 
@@ -18,10 +19,10 @@ cd /tmp
 if [ -f "$fname" -a -s "$fname" ]; then
 	echo "Found local file $fname, not downloading"
 else
-	echo "Missing or empty tar, downloading devel branch from git"
+	echo "Missing or empty tar, downloading branch $branch from git"
 	rm -- "$fname"
 	wget "$url" -O "$fname"
 fi
 tar xf "$fname"
-cd "btrfs-progs-$branch"
+cd "btrfs-progs-$fnbase"
 ci/build-default "$@"

--- a/ci/images/images-base-update
+++ b/ci/images/images-base-update
@@ -1,6 +1,7 @@
 #!/bin/sh
-
 # Update all base images from Dockefile
+# Run before: images-build-all
+
 for dir in ci-*; do
 	echo "Update $dir"
 	cd "$dir"

--- a/ci/images/images-build-all
+++ b/ci/images/images-build-all
@@ -1,9 +1,13 @@
 #!/bin/sh
-
 # Rebuild all docker images
+# Run after: images-base-update
+
 for dir in ci-*; do
 	echo "Build $dir"
 	cd "$dir"
+	# Do not build images with any stale branch snapshot, scripts ran
+	# locally will update that as needed
+	rm devel.tar.gz
 	./docker-build
 	cd ..
 done

--- a/ci/images/images-push-all
+++ b/ci/images/images-push-all
@@ -1,0 +1,16 @@
+#!/bin/sh
+# After pull and build push all images to the hub
+# Run after: images-build-all
+
+echo "You are not supposed to run this"
+exit 1
+
+hubname=kdave
+tag=latest
+
+for dir in ci-*; do
+	echo "Enter $dir"
+	dir="${dir,,}"
+	echo docker push "$hubname/$dir:$tag"
+	docker push "$hubname/$dir:$tag"
+done

--- a/ci/images/test-build
+++ b/ci/images/test-build
@@ -3,8 +3,9 @@
 
 urlbase="https://github.com/kdave/btrfs-progs/archive"
 branch=${1:-devel}
-fname="${branch}.tar.gz"
-url="${urlbase}/${fname}"
+fnbase="${branch/\//-}"
+fname="${fnbase}.tar.gz"
+url="${urlbase}/${branch}.tar.gz"
 
 shift
 
@@ -13,10 +14,10 @@ cd /tmp
 if [ -f "$fname" -a -s "$fname" ]; then
 	echo "Found local file $fname, not downloading"
 else
-	echo "Missing or empty tar, downloading devel branch from git"
+	echo "Missing or empty tar, downloading branch $branch from git"
 	rm -- "$fname"
 	wget "$url" -O "$fname"
 fi
 tar xf "$fname"
-cd "btrfs-progs-$branch"
+cd "btrfs-progs-$fnbase"
 ci/build-default "$@"

--- a/cmds/rescue.c
+++ b/cmds/rescue.c
@@ -451,6 +451,7 @@ static int cmd_rescue_clear_ino_cache(const struct cmd_struct *cmd,
 	} else {
 		pr_verbose(LOG_DEFAULT, "Successfully cleared ino cache");
 	}
+	close_ctree(fs_info->tree_root);
 out:
 	return !!ret;
 }

--- a/kernel-shared/ctree.h
+++ b/kernel-shared/ctree.h
@@ -404,6 +404,15 @@ struct btrfs_fs_info {
 	u32 sectorsize;
 	u32 stripesize;
 	u32 leaf_data_size;
+
+	/*
+	 * For open_ctree_fs_info() to hold the initial fd until close.
+	 *
+	 * For writeable open_ctree_fs_info() call, we should not close
+	 * the fd until the fs_info is properly closed, or it will trigger
+	 * udev scan while our fs is not properly initialized.
+	 */
+	int initial_fd;
 	u16 csum_type;
 	u16 csum_size;
 

--- a/kernel-shared/disk-io.c
+++ b/kernel-shared/disk-io.c
@@ -913,6 +913,7 @@ struct btrfs_fs_info *btrfs_new_fs_info(int writable, u64 sb_bytenr)
 	fs_info->metadata_alloc_profile = (u64)-1;
 	fs_info->system_alloc_profile = fs_info->metadata_alloc_profile;
 	fs_info->nr_global_roots = 1;
+	fs_info->initial_fd = -1;
 
 	return fs_info;
 
@@ -1690,7 +1691,10 @@ struct btrfs_fs_info *open_ctree_fs_info(struct open_ctree_args *oca)
 		return NULL;
 	}
 	info = __open_ctree_fd(fp, oca);
-	close(fp);
+	if (info)
+		info->initial_fd = fp;
+	else
+		close(fp);
 	return info;
 }
 
@@ -2297,6 +2301,8 @@ skip_commit:
 
 	btrfs_release_all_roots(fs_info);
 	ret = btrfs_close_devices(fs_info->fs_devices);
+	if (fs_info->initial_fd >= 0)
+		close(fs_info->initial_fd);
 	btrfs_cleanup_all_caches(fs_info);
 	btrfs_free_fs_info(fs_info);
 	if (!err)

--- a/tune/main.c
+++ b/tune/main.c
@@ -535,6 +535,7 @@ out:
 	}
 	close_ctree(root);
 	btrfs_close_all_devices();
+	close(fd);
 
 free_out:
 	return ret;


### PR DESCRIPTION
Although my previous flock() based solution is preventing udev scan to
get pre-mature super blocks, it in fact masks the root problem:

  There is a stray close() on writeable fd.

Commit b2a1be83b85f ("btrfs-progs: mkfs: keep file descriptors open
during whole time") tries to solve the problem by extending the lifespan
of writeable fds, so that when the fds are closed, the fs is ensured to
be properly populated.

The problem is, that patch is not covering all cases, there is a stray
fd close just under our noses: open_ctree_fs_info().

The function would open the initial device, then use that initial fd to
open the btrfs, then we immediately close the initial fd, as later IO
would all go with the device fd.

That close() call is causing problem, especially for mkfs, as at that
stage the fs is still using a temporary super block, not using the valid
btrfs super magic number.

Thus udev scan would race with mkfs, and if udev wins the race, it would
get the temporary super block, making libblk not to detect the new
btrfs.

This patchset would address the problem by:

- Make sure open_ctree*() calls all have corresponding close_ctree()
  The first patch, as later we will only close the initial fd caused by
  open_ctree_fs_info() during close_ctree().

- Save the initial fd into btrfs_fs_info for open_ctree_fs_info()
  And later close the initial fd during close_ctree().

- Make sure open_ctree_fd() callers to properly close the fd
  Just an extra cleanup.

This patchset would work even without the usage of flock() to block udev
scan, and since without flock() calls, the procedure is much simpler.

In theory, with this patchset, we can remove the flock(), as the flock() solution still has its own problem, as it can do infinite long wait.