### PR TITLE
Docs/conf.py: Set navigation_with_keys to allow navigating documentation through arrow keys

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -37,6 +37,10 @@ exclude_patterns = ['_build']
 # a list of builtin themes.
 html_theme = 'sphinx_rtd_theme'
 
+html_theme_options = {
+    'navigation_with_keys': True
+}
+
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".


### PR DESCRIPTION
Feature from https://github.com/sphinx-doc/sphinx/pull/2064.

I have not tested this (not sure how I would), but judging from other readthedocsprojects, it seems to be the correct way to set enable this.