### PR TITLE
Btrfs filesystem show JSON format support

### DIFF
--- a/Documentation/dev/dev-json.rst
+++ b/Documentation/dev/dev-json.rst
@@ -15,6 +15,7 @@ Commands that support json output
 
 * :command:`btrfs device stats`
 * :command:`btrfs filesystem df`
+* :command:`btrfs filesystem show`
 * :command:`btrfs qgroup show`
 * :command:`btrfs subvolume get-default`
 * :command:`btrfs subvolume list`

--- a/cmds/filesystem.c
+++ b/cmds/filesystem.c
@@ -431,8 +431,16 @@ static void print_one_uuid(struct format_ctx *fctx,
 
 	print_devices(fs_devices, &devs_found, unit_mode, fctx);
 
-	// TODO: global missing option?
 	if (bconf.output_format == CMD_FORMAT_JSON) {
+		if (devs_found < total) {
+			// TODO: Iterate over devs_found to find the missing device ids?
+			print_filesystem_device(fctx, 0,
+						 0, 0,
+						 "",
+						 true,
+						 unit_mode);
+			}
+
 		fmt_print_end_group(fctx, NULL);
 		fmt_print_end_group(fctx, "device-list");
 	} else {

--- a/cmds/filesystem.c
+++ b/cmds/filesystem.c
@@ -360,8 +360,8 @@ static void print_filesystem_device(struct format_ctx *fctx,
 	if (bconf.output_format == CMD_FORMAT_JSON) {
 		fmt_print_start_group(fctx, NULL, JSON_TYPE_MAP);
 		fmt_print(fctx, "devid", devid);
-		fmt_print(fctx, "size", 0);
-		fmt_print(fctx, "used", 0);
+		fmt_print(fctx, "size", total_bytes);
+		fmt_print(fctx, "used", bytes_used);
 		fmt_print(fctx, "path", path);
 		if (missing)
 			fmt_print(fctx, "missing", 0);

--- a/cmds/filesystem.c
+++ b/cmds/filesystem.c
@@ -363,8 +363,7 @@ static void print_filesystem_device(struct format_ctx *fctx,
 		fmt_print(fctx, "size", total_bytes);
 		fmt_print(fctx, "used", bytes_used);
 		fmt_print(fctx, "path", path);
-		if (missing)
-			fmt_print(fctx, "missing", 0);
+		fmt_print(fctx, "missing", missing);
 		fmt_print_end_group(fctx, NULL);
 	} else {
 		pr_verbose(LOG_DEFAULT, "\tdevid %4llu size %s used %s path %s%s\n",

--- a/kernel-shared/volumes.c
+++ b/kernel-shared/volumes.c
@@ -2434,7 +2434,7 @@ static int read_one_chunk(struct btrfs_fs_info *fs_info, struct btrfs_key *key,
 							NULL);
 		if (!map->stripes[i].dev) {
 			map->stripes[i].dev = fill_missing_device(devid, uuid);
-			printf("warning, device %llu is missing\n",
+			warning("warning, device %llu is missing\n",
 			       (unsigned long long)devid);
 			list_add(&map->stripes[i].dev->dev_list,
 				 &fs_info->fs_devices->devices);


### PR DESCRIPTION
Introduce JSON format support for `btrfs subvolume show`, there are two ways this information can be obtained either via an ioctl or via reading the block device. So I have taken the liberty of merging the print paths together in a re-usable function before adding JSON support.

I've chosen to format the JSON as I would have expected, an Object with "metadata" and the list of devices as part of that under `device-list`. See for example a single device volume:

```
{
  "__header": {
    "version": "1"
  },
  "filesystem-list": [
    {
      "label": "fedora",
      "uuid": "cece4dd8-6168-4c88-a4a8-f7c51ed4f82b",
      "total_devices": 1,
      "used": 3334180864,
      "device-list": [
        {
          "devid": 1,
          "size": 0,
          "used": 0,
          "path": "/dev/sda5"
        }
      ]
    }
  ]
}
```

There is one open issue, when you have an unmounted btrfs volume with multiple devices where one is missing it won't show up the json output:

```
{
  "__header": {
    "version": "1"
  },
WARNING: warning, device 2 is missing

  "filesystem-list": [
    {
      "label": "raid1",
      "uuid": "698b3250-9424-46c4-af61-372cc5468780",
      "total_devices": 2,
      "used": 638779392,
      "device-list": [
        {
          "devid": 1,
          "size": 0,
          "used": 0,
          "path": "/dev/sdb"
        }
      ]
    }
  ]
}
```

I could add a `missing_devices` property to the btrfs filesystem information but then that is inconsistent with the mounted missing device output (where it is a missing property in the device object).

Is it possible to show what device is missing for the unmounted case? So `btrfs subvolume show` would be consistent either way? (Seems device id is known, not sure about the path?).
