### PR TITLE
btrfs-progs: docs: fix incorrect description about compression with O…

### DIFF
--- a/Documentation/ch-compression.rst
+++ b/Documentation/ch-compression.rst
@@ -146,8 +146,8 @@ Compatibility
 
 Compression is done using the COW mechanism so it's incompatible with
 *nodatacow*. Direct IO works on compressed files but will fall back to buffered
-writes and leads to recompression. Currently *nodatasum* and compression don't
-work together.
+writes and leads to no compression even force compression is set.
+Currently *nodatasum* and compression don't work together.
 
 The compression algorithms have been added over time so the version
 compatibility should be also considered, together with other tools that may


### PR DESCRIPTION
According to the mail below, I found that docs about compression is incorrect.
After reading source code, I corrected these descriptions.

http://lore.kernel.org/linux-btrfs/e7ce9995-93cb-4904-875c-684d4494765f@web.de/