### PR TITLE
Headers cleanup

### DIFF
--- a/btrfs-corrupt-block.c
+++ b/btrfs-corrupt-block.c
@@ -20,7 +20,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <getopt.h>
-#include <limits.h>
 #include <errno.h>
 #include <string.h>
 #include <unistd.h>

--- a/btrfs-sb-mod.c
+++ b/btrfs-sb-mod.c
@@ -20,11 +20,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <inttypes.h>
 #include <string.h>
 #include <limits.h>
 #include <byteswap.h>
-#include "crypto/crc32c.h"
 #include "kernel-shared/disk-io.h"
 
 #define BLOCKSIZE (4096)

--- a/btrfs.c
+++ b/btrfs.c
@@ -28,7 +28,6 @@
 #include "common/utils.h"
 #include "common/string-utils.h"
 #include "common/help.h"
-#include "common/box.h"
 #include "common/messages.h"
 #include "cmds/commands.h"
 

--- a/cmds/device.c
+++ b/cmds/device.c
@@ -26,7 +26,6 @@
 #include <dirent.h>
 #include <stdbool.h>
 #include "kernel-shared/zoned.h"
-#include "kernel-shared/volumes.h"
 #include "common/string-table.h"
 #include "common/utils.h"
 #include "common/help.h"

--- a/cmds/filesystem-du.c
+++ b/cmds/filesystem-du.c
@@ -27,7 +27,6 @@
 #include <fcntl.h>
 #include <dirent.h>
 #include <errno.h>
-#include <limits.h>
 #include <stdbool.h>
 #include <unistd.h>
 #include "kernel-lib/rbtree.h"

--- a/cmds/filesystem-usage.c
+++ b/cmds/filesystem-usage.c
@@ -26,7 +26,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <dirent.h>
-#include <limits.h>
 #include <uuid/uuid.h>
 #include "kernel-lib/sizes.h"
 #include "kernel-shared/ctree.h"

--- a/cmds/inspect.c
+++ b/cmds/inspect.c
@@ -26,7 +26,6 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <getopt.h>
-#include <limits.h>
 #include <dirent.h>
 #include <string.h>
 #include <unistd.h>
@@ -45,8 +44,6 @@
 #include "common/open-utils.h"
 #include "common/units.h"
 #include "common/string-utils.h"
-#include "common/string-table.h"
-#include "common/sort-utils.h"
 #include "common/tree-search.h"
 #include "cmds/commands.h"
 

--- a/cmds/quota.c
+++ b/cmds/quota.c
@@ -16,7 +16,6 @@
  * Boston, MA 021110-1307, USA.
  */
 
-#include "kerncompat.h"
 #include <sys/ioctl.h>
 #include <dirent.h>
 #include <errno.h>

--- a/cmds/receive-dump.c
+++ b/cmds/receive-dump.c
@@ -17,7 +17,6 @@
  */
 
 #include "kerncompat.h"
-#include <limits.h>
 #include <time.h>
 #include <ctype.h>
 #include <errno.h>

--- a/cmds/receive.c
+++ b/cmds/receive.c
@@ -28,7 +28,6 @@
 #include <stdint.h>
 #include <fcntl.h>
 #include <getopt.h>
-#include <limits.h>
 #include <errno.h>
 #include <endian.h>
 #include <stdbool.h>

--- a/cmds/reflink.c
+++ b/cmds/reflink.c
@@ -23,8 +23,6 @@
 #include <unistd.h>
 #include "kernel-lib/list.h"
 #include "common/messages.h"
-#include "common/open-utils.h"
-#include "common/parse-utils.h"
 #include "common/string-utils.h"
 #include "common/help.h"
 #include "cmds/commands.h"

--- a/cmds/restore.c
+++ b/cmds/restore.c
@@ -28,7 +28,6 @@
 #include <regex.h>
 #include <getopt.h>
 #include <errno.h>
-#include <limits.h>
 #include <stddef.h>
 #include <string.h>
 #if COMPRESSION_LZO

--- a/cmds/scrub.c
+++ b/cmds/scrub.c
@@ -31,7 +31,6 @@
 #include <ctype.h>
 #include <signal.h>
 #include <stdarg.h>
-#include <limits.h>
 #include <dirent.h>
 #include <getopt.h>
 #include <errno.h>
@@ -50,11 +49,9 @@
 #include "common/open-utils.h"
 #include "common/units.h"
 #include "common/device-utils.h"
-#include "common/parse-utils.h"
 #include "common/sysfs-utils.h"
 #include "common/string-table.h"
 #include "common/string-utils.h"
-#include "common/parse-utils.h"
 #include "common/help.h"
 #include "cmds/commands.h"
 

--- a/common/device-scan.c
+++ b/common/device-scan.c
@@ -28,7 +28,6 @@
 #include <unistd.h>
 #include <errno.h>
 #include <dirent.h>
-#include <limits.h>
 #include <stdbool.h>
 #include <blkid/blkid.h>
 #include <uuid/uuid.h>

--- a/common/open-utils.c
+++ b/common/open-utils.c
@@ -22,7 +22,6 @@
 #include <fcntl.h>
 #include <mntent.h>
 #include <errno.h>
-#include <limits.h>
 #include <stdio.h>
 #include <string.h>
 #include "kernel-lib/list.h"

--- a/common/path-utils.c
+++ b/common/path-utils.c
@@ -29,7 +29,6 @@
 #include <errno.h>
 #include <ctype.h>
 #include <libgen.h>
-#include <limits.h>
 #include "common/path-utils.h"
 
 /*

--- a/common/send-stream.c
+++ b/common/send-stream.c
@@ -22,7 +22,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#include "kernel-shared/accessors.h"
 #include "kernel-shared/uapi/btrfs_tree.h"
 #include "kernel-shared/uapi/btrfs.h"
 #include "kernel-shared/send.h"

--- a/common/send-utils.c
+++ b/common/send-utils.c
@@ -20,7 +20,6 @@
 #include <sys/ioctl.h>
 #include <unistd.h>
 #include <fcntl.h>
-#include <limits.h>
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/common/string-utils.c
+++ b/common/string-utils.c
@@ -16,8 +16,6 @@
 
 #include "kerncompat.h"
 #include <stdlib.h>
-#include <stdio.h>
-#include <limits.h>
 #include "common/string-utils.h"
 #include "common/messages.h"
 #include "common/parse-utils.h"

--- a/common/units.h
+++ b/common/units.h
@@ -43,7 +43,12 @@
 
 const char *pretty_size_mode(u64 size, unsigned mode);
 int pretty_size_snprintf(u64 size, char *str, size_t str_size, unsigned unit_mode);
-#define pretty_size(size) 	pretty_size_mode(size, UNITS_DEFAULT)
+
+static inline const char *pretty_size(u64 size)
+{
+	return pretty_size_mode(size, UNITS_DEFAULT);
+}
+
 void units_set_mode(unsigned *units, unsigned mode);
 void units_set_base(unsigned *units, unsigned base);
 unsigned int get_unit_mode_from_arg(int *argc, char *argv[], int df_mode);

--- a/common/utils.c
+++ b/common/utils.c
@@ -32,7 +32,6 @@
 #include <unistd.h>
 #include <mntent.h>
 #include <ctype.h>
-#include <limits.h>
 #include <strings.h>
 #include "kernel-lib/list.h"
 #include "kernel-shared/accessors.h"

--- a/convert/main.c
+++ b/convert/main.c
@@ -91,7 +91,6 @@
 #include <pthread.h>
 #include <stdbool.h>
 #include <errno.h>
-#include <limits.h>
 #include <string.h>
 #include <uuid/uuid.h>
 #include "kernel-lib/sizes.h"

--- a/convert/source-ext2.c
+++ b/convert/source-ext2.c
@@ -21,7 +21,6 @@
 #include <linux/limits.h>
 #include <errno.h>
 #include <pthread.h>
-#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/kernel-lib/mktables.c
+++ b/kernel-lib/mktables.c
@@ -17,15 +17,12 @@
 
 /*
  * Btrfs-progs port, with following minor fixes:
- * 1) Use "kerncompat.h"
+ * 1) Use "kerncompat.h" header for generated tables.c
  * 2) Get rid of __KERNEL__ related macros
  */
 
 #include <stdio.h>
-#include <string.h>
 #include <inttypes.h>
-#include <stdlib.h>
-#include <time.h>
 
 static uint8_t gfmul(uint8_t a, uint8_t b)
 {

--- a/kernel-shared/dir-item.c
+++ b/kernel-shared/dir-item.c
@@ -21,7 +21,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
-#include "kernel-lib/bitops.h"
 #include "kernel-shared/ctree.h"
 #include "kernel-shared/disk-io.h"
 #include "kernel-shared/accessors.h"

--- a/kernel-shared/extent-tree.c
+++ b/kernel-shared/extent-tree.c
@@ -22,7 +22,6 @@
 #include <stdbool.h>
 #include <errno.h>
 #include <string.h>
-#include "kernel-lib/bitops.h"
 #include "kernel-lib/list.h"
 #include "kernel-lib/rbtree.h"
 #include "kernel-lib/rbtree_types.h"

--- a/kernel-shared/file-item.c
+++ b/kernel-shared/file-item.c
@@ -24,7 +24,6 @@
 #include "kernel-shared/transaction.h"
 #include "kernel-shared/file-item.h"
 #include "kernel-shared/extent_io.h"
-#include "kernel-shared/uapi/btrfs.h"
 #include "common/internal.h"
 
 #define MAX_CSUM_ITEMS(r, size) ((((BTRFS_LEAF_DATA_SIZE(r->fs_info) - \

--- a/kernel-shared/file.c
+++ b/kernel-shared/file.c
@@ -19,10 +19,8 @@
 #include "kerncompat.h"
 #include <errno.h>
 #include <string.h>
-#include "kernel-lib/bitops.h"
 #include "kernel-shared/accessors.h"
 #include "kernel-shared/extent_io.h"
-#include "kernel-shared/uapi/btrfs.h"
 #include "kernel-shared/uapi/btrfs_tree.h"
 #include "kernel-shared/ctree.h"
 #include "kernel-shared/compression.h"

--- a/kernel-shared/inode-item.c
+++ b/kernel-shared/inode-item.c
@@ -19,10 +19,8 @@
 #include "kerncompat.h"
 #include <errno.h>
 #include <stddef.h>
-#include "kernel-lib/bitops.h"
 #include "kernel-shared/accessors.h"
 #include "kernel-shared/extent_io.h"
-#include "kernel-shared/uapi/btrfs.h"
 #include "kernel-shared/uapi/btrfs_tree.h"
 #include "kernel-shared/ctree.h"
 #include "kernel-shared/disk-io.h"

--- a/kernel-shared/messages.c
+++ b/kernel-shared/messages.c
@@ -3,7 +3,6 @@
 #include "kerncompat.h"
 #include <errno.h>
 #include <stdarg.h>
-#include "kernel-lib/bitops.h"
 #include "kernel-shared/ctree.h"
 #include "kernel-shared/messages.h"
 

--- a/kernel-shared/root-tree.c
+++ b/kernel-shared/root-tree.c
@@ -19,7 +19,6 @@
 #include "kerncompat.h"
 #include <errno.h>
 #include <string.h>
-#include "kernel-lib/bitops.h"
 #include "kernel-shared/accessors.h"
 #include "kernel-shared/messages.h"
 #include "kernel-shared/extent_io.h"

--- a/kernel-shared/tree-checker.c
+++ b/kernel-shared/tree-checker.c
@@ -19,7 +19,6 @@
 #include <sys/stat.h>
 #include <linux/limits.h>
 #include <errno.h>
-#include <limits.h>
 #include <stdarg.h>
 #include "kernel-lib/overflow.h"
 #include "kernel-lib/bitops.h"

--- a/kernel-shared/uuid-tree.c
+++ b/kernel-shared/uuid-tree.c
@@ -21,7 +21,6 @@
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>
-#include "kernel-lib/bitops.h"
 #include "kernel-shared/accessors.h"
 #include "kernel-shared/extent_io.h"
 #include "kernel-shared/uapi/btrfs.h"
@@ -29,8 +28,6 @@
 #include "kernel-shared/ctree.h"
 #include "kernel-shared/messages.h"
 #include "kernel-shared/transaction.h"
-#include "common/messages.h"
-#include "common/utils.h"
 
 void btrfs_uuid_to_key(const u8 *uuid, u8 type, struct btrfs_key *key)
 {

--- a/kernel-shared/zoned.c
+++ b/kernel-shared/zoned.c
@@ -28,7 +28,6 @@
 #include "kernel-shared/accessors.h"
 #include "kernel-shared/ctree.h"
 #include "kernel-shared/extent_io.h"
-#include "kernel-shared/uapi/btrfs.h"
 #include "kernel-shared/uapi/btrfs_tree.h"
 #include "common/utils.h"
 #include "common/device-utils.h"

--- a/libbtrfs/crc32c.c
+++ b/libbtrfs/crc32c.c
@@ -8,7 +8,6 @@
  *
  */
 
-#include <inttypes.h>
 #include "libbtrfs/crc32c.h"
 
 uint32_t __crc32c_le(uint32_t crc, unsigned char const *data, uint32_t length);
@@ -53,7 +52,7 @@ static uint32_t crc32c_intel_le_hw_byte(uint32_t crc, unsigned char const *data,
 }
 
 /*
- * Steps through buffer one byte at at time, calculates reflected 
+ * Steps through buffer one byte at at time, calculates reflected
  * crc using table.
  */
 static uint32_t crc32c_intel(uint32_t crc, unsigned char const *data, uint32_t length)
@@ -198,7 +197,7 @@ static const uint32_t crc32c_table[256] = {
 };
 
 /*
- * Steps through buffer one byte at at time, calculates reflected 
+ * Steps through buffer one byte at at time, calculates reflected
  * crc using table.
  */
 

--- a/mkfs/common.c
+++ b/mkfs/common.c
@@ -249,8 +249,8 @@ static int create_block_group_tree(int fd, struct btrfs_mkfs_config *cfg,
 	btrfs_set_header_nritems(buf, 1);
 	csum_tree_block_size(buf, btrfs_csum_type_size(cfg->csum_type), 0,
 			     cfg->csum_type);
-	ret = pwrite(fd, buf->data, cfg->nodesize,
-		     cfg->blocks[MKFS_BLOCK_GROUP_TREE]);
+	ret = btrfs_pwrite(fd, buf->data, cfg->nodesize,
+			   cfg->blocks[MKFS_BLOCK_GROUP_TREE], cfg->zone_size);
 	if (ret != cfg->nodesize)
 		return ret < 0 ? -errno : -EIO;
 	return 0;

--- a/mkfs/common.c
+++ b/mkfs/common.c
@@ -17,7 +17,6 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <fcntl.h>
-#include <limits.h>
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/mkfs/rootdir.c
+++ b/mkfs/rootdir.c
@@ -24,7 +24,6 @@
 #include <fcntl.h>
 #include <ftw.h>
 #include <errno.h>
-#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 #include "kernel-lib/sizes.h"

--- a/tests/fsstress.c
+++ b/tests/fsstress.c
@@ -32,7 +32,6 @@
 #include <fcntl.h>
 #include <assert.h>
 #include <getopt.h>
-#include "common/internal.h"
 
 #define AIO
 #define URING
@@ -1434,7 +1433,7 @@ fent_to_name(pathname_t *name, fent_t *fep)
 		if (pfep == NULL) {
 			fprintf(stderr, "%d: fent-id = %d: can't find parent id: %d\n",
 				procid, fep->id, fep->parent);
-		} 
+		}
 #endif
 		if (pfep == NULL)
 			return 0;
@@ -1545,7 +1544,7 @@ int generate_xattr_name(int xattr_num, char *buffer, int buflen)
 }
 
 /*
- * Get file 
+ * Get file
  * Input: "which" to choose the file-types eg. non-directory
  * Input: "r" to choose which file
  * Output: file-list, file-entry, name for the chosen file.
@@ -1585,7 +1584,7 @@ get_fname(int which, long r, pathname_t *name, flist_t **flpp, fent_t **fepp,
 	 * Now we have possible matches between 0..totalsum-1.
 	 * And we use r to help us choose which one we want,
 	 * which when bounded by totalsum becomes x.
-	 */ 
+	 */
 	x = (int)(r % totalsum);
 	for (i = 0, flp = flist; i < FT_nft; i++, flp++) {
 		if (which & (1U << i)) {
@@ -1600,7 +1599,7 @@ get_fname(int which, long r, pathname_t *name, flist_t **flpp, fent_t **fepp,
 #ifdef DEBUG
 					if (!e) {
 						fprintf(stderr, "%d: failed to get path for entry:"
-								" id=%d,parent=%d\n", 	
+								" id=%d,parent=%d\n",
 							procid, fep->id, fep->parent);
 					}
 #endif
@@ -2007,7 +2006,7 @@ show_ops(int flag, char *lead_str)
         if (flag<0) {
                 /* print in list form */
                 int             x = WIDTH;
-                
+
 	        for (p = ops; p < ops_end; p++) {
 			if (lead_str != NULL && x+strlen(p->name)>=WIDTH-5)
 				x=printf("%s%s", (p==ops)?"":"\n", lead_str);
@@ -2069,7 +2068,7 @@ symlink_path(const char *name1, pathname_t *name)
 	char		buf[NAME_MAX + 1];
 	pathname_t	newname;
 	int		rval;
-        
+
         if (!strcmp(name1, name->path)) {
             printf("yikes! %s %s\n", name1, name->path);
             return 0;
@@ -2647,7 +2646,7 @@ bulkstat_f(opnum_t opno, long r)
         bsr.icount=nent;
         bsr.ubuffer=t;
         bsr.ocount=&count;
-            
+
 	while (xfsctl(".", fd, XFS_IOC_FSBULKSTAT, &bsr) == 0 && count > 0)
 		total += count;
 	free(t);
@@ -2680,8 +2679,8 @@ bulkstat1_f(opnum_t opno, long r)
 		check_cwd();
 		free_pathname(&f);
 	} else {
-                /* 
-                 * pick a random inode 
+                /*
+                 * pick a random inode
                  *
                  * note this can generate kernel warning messages
                  * since bulkstat_one will read the disk block that
@@ -2698,7 +2697,7 @@ bulkstat1_f(opnum_t opno, long r)
 		v = verbose;
 	}
 	fd = open(".", O_RDONLY);
-        
+
         bsr.lastip=&ino;
         bsr.icount=1;
         bsr.ubuffer=&t;
@@ -3797,7 +3796,7 @@ dread_f(opnum_t opno, long r)
 	len -= (len % align);
 	if (len <= 0)
 		len = align;
-	else if (len > diob.d_maxiosz) 
+	else if (len > diob.d_maxiosz)
 		len = diob.d_maxiosz;
 	buf = memalign(diob.d_mem, len);
 	e = read(fd, buf, len) < 0 ? errno : 0;
@@ -3874,7 +3873,7 @@ dwrite_f(opnum_t opno, long r)
 	len -= (len % align);
 	if (len <= 0)
 		len = align;
-	else if (len > diob.d_maxiosz) 
+	else if (len > diob.d_maxiosz)
 		len = diob.d_maxiosz;
 	buf = memalign(diob.d_mem, len);
 	off %= maxfsize;

--- a/tests/ioctl-test.c
+++ b/tests/ioctl-test.c
@@ -19,7 +19,6 @@
 #include <stdlib.h>
 
 #include "kernel-shared/uapi/btrfs.h"
-#include "kernel-shared/ctree.h"
 
 #define LIST_32_COMPAT				\
 	ONE(BTRFS_IOC_SET_RECEIVED_SUBVOL_32)

--- a/tests/library-test.c
+++ b/tests/library-test.c
@@ -16,31 +16,15 @@
  * Boston, MA 021110-1307, USA.
  */
 
-#if BTRFS_FLAT_INCLUDES
-#include "libbtrfs/kerncompat.h"
-#include "libbtrfs/version.h"
-#include "libbtrfs/ioctl.h"
-#include "kernel-lib/rbtree.h"
-#include "kernel-lib/list.h"
-#include "kernel-shared/ctree.h"
-#include "kernel-shared/send.h"
-#include "common/send-stream.h"
-#include "common/send-utils.h"
-#else
 /*
- * This needs to include headers the same way as an external program but must
- * not use the existing system headers, so we use "...".
+ * This program is only linked to libbtrfsutil library, and only include
+ * headers from libbtrfsutil, so we do not use the filepath inside btrfs-progs
+ * source code.
  */
 #include "btrfs/kerncompat.h"
 #include "btrfs/version.h"
-#include "btrfs/rbtree.h"
-#include "btrfs/list.h"
-#include "btrfs/ctree.h"
-#include "btrfs/ioctl.h"
-#include "btrfs/send.h"
 #include "btrfs/send-stream.h"
 #include "btrfs/send-utils.h"
-#endif
 
 /*
  * Reduced code snippet from snapper.git/snapper/Btrfs.cc

--- a/tests/misc-tests/063-btrfstune-zoned-bgt/test.sh
+++ b/tests/misc-tests/063-btrfstune-zoned-bgt/test.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Verify btrfstune for zoned devices with block-group-tree conversion
+
+source "$TEST_TOP/common" || exit
+
+setup_root_helper
+prepare_test_dev
+
+nullb="$TEST_TOP/nullb"
+# Create one 128M device with 4M zones, 32 of them
+size=128
+zone=4
+
+run_mayfail $SUDO_HELPER "$nullb" setup
+if [ $? != 0 ]; then
+	_not_run "cannot setup nullb environment for zoned devices"
+fi
+
+# Record any other pre-existing devices in case creation fails
+run_check $SUDO_HELPER "$nullb" ls
+
+# Last line has the name of the device node path
+out=$(run_check_stdout $SUDO_HELPER "$nullb" create -s "$size" -z "$zone")
+if [ $? != 0 ]; then
+	_fail "cannot create nullb zoned device $i"
+fi
+dev=$(echo "$out" | tail -n 1)
+name=$(basename "${dev}")
+
+run_check $SUDO_HELPER "$nullb" ls
+
+TEST_DEV="${dev}"
+
+# Create the fs without bgt
+run_check $SUDO_HELPER "$TOP/mkfs.btrfs" -f -m single -d single -O ^block-group-tree "${dev}"
+run_check_mount_test_dev
+run_check $SUDO_HELPER dd if=/dev/zero of="$TEST_MNT"/file1 bs=1M count=1
+run_check $SUDO_HELPER "$TOP/btrfs" filesystem usage -T "$TEST_MNT"
+run_check_umount_test_dev
+
+# Convert to bgt
+run_check $SUDO_HELPER "$TOP/btrfstune" --convert-to-block-group-tree "${dev}"
+run_check_mount_test_dev
+run_check $SUDO_HELPER dd if=/dev/zero of="$TEST_MNT"/file2 bs=1M count=1
+run_check $SUDO_HELPER "$TOP/btrfs" filesystem usage -T "$TEST_MNT"
+run_check_umount_test_dev
+
+# And convert back to old extent tree
+run_check $SUDO_HELPER "$TOP/btrfstune" --convert-from-block-group-tree "${dev}"
+run_check_mount_test_dev
+run_check $SUDO_HELPER dd if=/dev/zero of="$TEST_MNT"/file3 bs=1M count=1
+run_check $SUDO_HELPER "$TOP/btrfs" filesystem usage -T "$TEST_MNT"
+run_check_umount_test_dev
+
+run_check $SUDO_HELPER "$nullb" rm "${name}"

--- a/tests/mkfs-tests/031-zoned-bgt/test.sh
+++ b/tests/mkfs-tests/031-zoned-bgt/test.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Verify mkfs for zoned devices support block-group-tree feature
+
+source "$TEST_TOP/common" || exit
+
+setup_root_helper
+prepare_test_dev
+
+nullb="$TEST_TOP/nullb"
+# Create one 128M device with 4M zones, 32 of them
+size=128
+zone=4
+
+run_mayfail $SUDO_HELPER "$nullb" setup
+if [ $? != 0 ]; then
+	_not_run "cannot setup nullb environment for zoned devices"
+fi
+
+# Record any other pre-existing devices in case creation fails
+run_check $SUDO_HELPER "$nullb" ls
+
+# Last line has the name of the device node path
+out=$(run_check_stdout $SUDO_HELPER "$nullb" create -s "$size" -z "$zone")
+if [ $? != 0 ]; then
+	_fail "cannot create nullb zoned device $i"
+fi
+dev=$(echo "$out" | tail -n 1)
+name=$(basename "${dev}")
+
+run_check $SUDO_HELPER "$nullb" ls
+
+TEST_DEV="${dev}"
+# Use single as it's supported on more kernels
+run_check $SUDO_HELPER "$TOP/mkfs.btrfs" -m single -d single -O block-group-tree "${dev}"
+run_check_mount_test_dev
+run_check $SUDO_HELPER dd if=/dev/zero of="$TEST_MNT"/file bs=1M count=1
+run_check $SUDO_HELPER "$TOP/btrfs" filesystem usage -T "$TEST_MNT"
+run_check_umount_test_dev
+
+run_check $SUDO_HELPER "$nullb" rm "${name}"

--- a/tune/convert-bgt.c
+++ b/tune/convert-bgt.c
@@ -270,7 +270,7 @@ iterate_bgs:
 		return ret;
 	}
 	pr_verbose(LOG_DEFAULT,
-		"Converted filesystem with block-group-tree to extent tree feature");
+		"Converted filesystem with block-group-tree to extent tree feature\n");
 	return 0;
 
 error:

--- a/tune/main.c
+++ b/tune/main.c
@@ -29,6 +29,7 @@
 #include "kernel-shared/transaction.h"
 #include "kernel-shared/volumes.h"
 #include "kernel-shared/free-space-tree.h"
+#include "kernel-shared/zoned.h"
 #include "common/utils.h"
 #include "common/open-utils.h"
 #include "common/device-scan.h"
@@ -193,6 +194,7 @@ int BOX_MAIN(btrfstune)(int argc, char *argv[])
 	u64 super_flags = 0;
 	int quota = 0;
 	int fd = -1;
+	int oflags = O_RDWR;
 
 	btrfs_config_init();
 
@@ -336,7 +338,9 @@ int BOX_MAIN(btrfstune)(int argc, char *argv[])
 		}
 	}
 
-	fd = open(device, O_RDWR);
+	if (zoned_model(device) == ZONED_HOST_MANAGED)
+		oflags |= O_DIRECT;
+	fd = open(device, oflags);
 	if (fd < 0) {
 		error("mount check: cannot open %s: %m", device);
 		ret = 1;

--- a/tune/main.c
+++ b/tune/main.c
@@ -33,7 +33,6 @@
 #include "common/open-utils.h"
 #include "common/device-scan.h"
 #include "common/messages.h"
-#include "common/parse-utils.h"
 #include "common/string-utils.h"
 #include "common/help.h"
 #include "common/box.h"


### PR DESCRIPTION
This series is focusing on cleanup the unused headers.

This is mostly done by clangd, although it has some false alerts related
to macro usages of a header.

But still it's pretty awesome to cleanup a lot of unnecessary headers.
Only one special touch on pretty_size() macro, to change it to a static
inline function to workaround the clangd bug.

The first patch would do the main heavy lifting, meanwhile the second
patch is doing the BTRFS_FLAT_INCLUDES related cleanups for library-test
code.

Unfortunately I didn't touch anything inside crypto/*, the main reason
is I'm not confident enough to verify all the optimization for different
instructions.

(And even less motivation after the infamous recent XZ backdoor attempt,
 by a possibly state-sponsored sleeping agent, ruining the trust among
 open source community.)
