### PR TITLE
filesystem resize documentation improvements

### DIFF
--- a/Documentation/btrfs-filesystem.rst
+++ b/Documentation/btrfs-filesystem.rst
@@ -255,6 +255,14 @@ resize [options] [<devid>:][+/-]<size>[kKmMgGtTpPeE]|[<devid>:]max <path>
         :manref:`fdisk(8)` or :manref:`parted(8)` to delete the existing partition and recreate
         it with the new desired size.  When recreating the partition make sure to use
         the same starting partition offset as before.
+        The size of the portion that the filesystem uses of an underlying device can be
+        determined via the :command:`btrfs filesystem show --raw` command on the
+        filesystem’s mount point (where it’s given for each *devid* after the string
+        `size` or via the :command:`btrfs inspect-internal dump-super` command on the
+        specific device (where it’s given as the value of `dev_item.total_bytes`, which
+        is not to be confused with `total_bytes`).
+        The value is also the address of the first byte not used by the
+        filesystem.
 
         Growing is usually instant as it only updates the size. However, shrinking could
         take a long time if there are data in the device area that's beyond the new

--- a/Documentation/btrfs-filesystem.rst
+++ b/Documentation/btrfs-filesystem.rst
@@ -250,7 +250,7 @@ resize [options] [<devid>:][+/-]<size>[kKmMgGtTpPeE]|[<devid>:]max <path>
 
         The resize command does not manipulate the size of underlying
         partition.  If you wish to enlarge/reduce a filesystem, you must make sure you
-        can expand the partition before enlarging the filesystem and shrink the
+        expand the partition before enlarging the filesystem and shrink the
         partition after reducing the size of the filesystem.  This can done using
         :manref:`fdisk(8)` or :manref:`parted(8)` to delete the existing partition and recreate
         it with the new desired size.  When recreating the partition make sure to use


### PR DESCRIPTION
Please review.

Further TODO:
- I think it would be valuable to tell people in which steps they can reasonable shrink/enlarge a fs. In some try, where I made the underlying partition on purpose one sector (512B) larger and then tried `resize max`, btrfs didn't claim that 512B.
   I’d blindly guess it's one `sectorsize` as given by `btrfs inspect-internal dump-super`, what btrfs needs at least?
   If someone confirms I could make another commit that adds that information.
- For sysadmins which are bad at mental arithmetic, it would be nice if they'd knew, whether btrfs warns/errors if the underlying device is smaller than the size that it wants to use of it? Does it do so, e.g. at mount time, fskc or even while mounted?
   If so I could add that as well.