### PR TITLE
btrfs-progs: cmds/qgroup: enhance stale qgroups handling

### DIFF
--- a/Documentation/btrfs-qgroup.rst
+++ b/Documentation/btrfs-qgroup.rst
@@ -153,6 +153,30 @@ show [options] <path>
                 To retrieve information after updating the state of qgroups,
                 force sync of the filesystem identified by *path* before getting information.
 
+SPECIAL PATHS
+-------------
+For `btrfs qgroup show` subcommand, the ``path`` column may has some special
+strings:
+
+`<toplevel>`
+	The toplevel subvolume
+
+`<under deletion>`
+	The subvolume is unlinked, but not yet fully deleted.
+
+`<squota space holder>`
+	For simple quota mode only.
+	By its design, a fully deleted subvolume may still have accounting on
+	it, so even the subvolume is gone, the numbers are still here for future
+	accounting.
+
+`<stale>`
+	The qgroup has no corresponding subvolume anymore, and the qgroup
+	can be cleaned up under most cases.
+	The only exception is that, if the qgroup numbers are inconsistent and
+	the qgroup numbers are not all zeros, some older kernels may refuse to
+	delete such qgroups until a full rescan.
+
 QUOTA RESCAN
 ------------
 

--- a/cmds/qgroup.c
+++ b/cmds/qgroup.c
@@ -2135,6 +2135,7 @@ static const char * const cmd_qgroup_clear_stale_usage[] = {
 
 static int cmd_qgroup_clear_stale(const struct cmd_struct *cmd, int argc, char **argv)
 {
+	enum btrfs_util_error err;
 	int ret = 0;
 	int fd;
 	char *path = NULL;
@@ -2150,6 +2151,11 @@ static int cmd_qgroup_clear_stale(const struct cmd_struct *cmd, int argc, char *
 	fd = btrfs_open_dir(path);
 	if (fd < 0)
 		return 1;
+
+	/* Sync the fs so that the qgroup numbers are uptodate. */
+	err = btrfs_util_sync_fd(fd);
+	if (err)
+		warning("sync ioctl failed on '%s': %m", path);
 
 	ret = qgroups_search_all(fd, &qgroup_lookup);
 	if (ret == -ENOTTY) {

--- a/cmds/qgroup.c
+++ b/cmds/qgroup.c
@@ -65,6 +65,8 @@ struct btrfs_qgroup_list {
 };
 
 struct qgroup_lookup {
+	/* This matches btrfs_qgroup_status_item::flags. */
+	u64 flags;
 	struct rb_root root;
 };
 
@@ -1313,6 +1315,7 @@ static int __qgroups_search(int fd, struct btrfs_tree_search_args *args,
 			case BTRFS_QGROUP_STATUS_KEY:
 				si = btrfs_tree_search_data(args, off);
 				flags = btrfs_stack_qgroup_status_flags(si);
+				qgroup_lookup->flags = flags;
 
 				print_status_flag_warning(flags);
 				break;

--- a/cmds/qgroup.c
+++ b/cmds/qgroup.c
@@ -80,8 +80,23 @@ struct btrfs_qgroup {
 	struct rb_node all_parent_node;
 	u64 qgroupid;
 
-	/* NULL for qgroups with level > 0 */
+	/*
+	 * NULL for qgroups with level > 0 or the subvolume is *unlinked*.
+	 *
+	 * Note that, an unlinked subvolume doesn't mean it has been fully
+	 * dropped, so callers should not rely on this to determine if
+	 * a qgroup is stale.
+	 *
+	 * This member is only to help locating the path of the corresponding
+	 * subvolume.
+	 */
 	const char *path;
+
+	/*
+	 * This is only true if the qgroup is level 0 qgroup, and there is
+	 * no subvolume tree for the qgroup at all.
+	 */
+	bool stale;
 
 	/*
 	 * info_item
@@ -229,6 +244,12 @@ static struct {
 static btrfs_qgroup_filter_func all_filter_funcs[];
 static btrfs_qgroup_comp_func all_comp_funcs[];
 
+static bool is_qgroup_empty(struct btrfs_qgroup *qg)
+{
+	return !(qg->info.referenced || qg->info.exclusive ||
+		 qg->info.referenced_compressed ||
+		 qg->info.exclusive_compressed);
+}
 static void qgroup_setup_print_column(enum btrfs_qgroup_column_enum column)
 {
 	int i;
@@ -795,13 +816,30 @@ static struct btrfs_qgroup *get_or_add_qgroup(int fd,
 		uret = btrfs_util_subvolume_path_fd(fd, qgroupid, &path);
 		if (uret == BTRFS_UTIL_OK)
 			bq->path = path;
-		/* Ignore stale qgroup items */
 		else if (uret != BTRFS_UTIL_ERROR_SUBVOLUME_NOT_FOUND) {
 			error("%s", btrfs_util_strerror(uret));
 			if (uret == BTRFS_UTIL_ERROR_NO_MEMORY)
 				return ERR_PTR(-ENOMEM);
 			else
 				return ERR_PTR(-EIO);
+		}
+		/*
+		 * Do a correct stale detection by searching for the ROOT_ITEM of
+		 * the subvolume.
+		 *
+		 * Passing @subvol as NULL will force the search to only search
+		 * for the ROOT_ITEM.
+		 */
+		uret = btrfs_util_subvolume_info_fd(fd, qgroupid, NULL);
+		if (uret == BTRFS_UTIL_OK) {
+			bq->stale = false;
+		} else if (uret == BTRFS_UTIL_ERROR_SUBVOLUME_NOT_FOUND) {
+			bq->stale = true;
+		} else {
+			warning("failed to search root item for qgroup %u/%llu, assuming it not stale",
+				btrfs_qgroup_level(qgroupid),
+				btrfs_qgroup_subvolid(qgroupid));
+			bq->stale = false;
 		}
 	}
 
@@ -2136,6 +2174,65 @@ static const char * const cmd_qgroup_clear_stale_usage[] = {
 	NULL
 };
 
+/*
+ * Return >0 if the qgroup should or can not be deleted.
+ * Return 0 if the qgroup is deleted.
+ * Return <0 for critical error.
+ */
+static int delete_one_stale_qgroup(struct qgroup_lookup *lookup,
+				   struct btrfs_qgroup *qg, int fd)
+{
+	u16 level = btrfs_qgroup_level(qg->qgroupid);
+	struct btrfs_ioctl_qgroup_create_args args = { .create = false };
+	const bool inconsistent = lookup->flags & BTRFS_QGROUP_STATUS_FLAG_INCONSISTENT;
+	const bool squota = lookup->flags & BTRFS_QGROUP_STATUS_FLAG_SIMPLE_MODE;
+	const bool empty = is_qgroup_empty(qg);
+	bool attempt = false;
+	int ret;
+
+	if (level || !qg->stale)
+		return 1;
+
+	/*
+	 * By design, squota can have a subvolume fully dropped but its qgroup numbers
+	 * are not zero.
+	 * Such qgroup is still needed for future accounting, thus can not be deleted.
+	 */
+	if (squota && !empty)
+		return 1;
+
+	/*
+	 * We can have inconsistent qgroup numbers, in that case a really stale
+	 * qgroup can exist while its numbers are not zero.
+	 *
+	 * In this case we only attempt to delete the qgroup, depending on the
+	 * kernel implementation, we may or may not be able to delete it.
+	 */
+	if (inconsistent && !empty)
+		attempt = true;
+
+	if (attempt)
+		pr_verbose(LOG_DEFAULT,
+		"Attempt to delete stale but non-empty qgroup %u/%llu\n",
+			   level, btrfs_qgroup_subvolid(qg->qgroupid));
+	else
+		pr_verbose(LOG_DEFAULT, "Delete stale qgroup %u/%llu\n",
+			   level, btrfs_qgroup_subvolid(qg->qgroupid));
+	args.qgroupid = qg->qgroupid;
+	ret = ioctl(fd, BTRFS_IOC_QGROUP_CREATE, &args);
+	if (ret < 0) {
+		if (attempt) {
+			warning("not supported to delete non-empty stale qgroup %u/%llu",
+				level, btrfs_qgroup_subvolid(qg->qgroupid));
+			ret = 1;
+		} else {
+			error("failed to delete qgroup %u/%llu",
+				level, btrfs_qgroup_subvolid(qg->qgroupid));
+		}
+	}
+	return ret;
+}
+
 static int cmd_qgroup_clear_stale(const struct cmd_struct *cmd, int argc, char **argv)
 {
 	enum btrfs_util_error err;
@@ -2172,22 +2269,12 @@ static int cmd_qgroup_clear_stale(const struct cmd_struct *cmd, int argc, char *
 
 	node = rb_first(&qgroup_lookup.root);
 	while (node) {
-		u64 level;
-		struct btrfs_ioctl_qgroup_create_args args = { .create = false };
+		int delete_ret;
 
 		entry = rb_entry(node, struct btrfs_qgroup, rb_node);
-		level = btrfs_qgroup_level(entry->qgroupid);
-		if (!entry->path && level == 0) {
-			pr_verbose(LOG_DEFAULT, "Delete stale qgroup %llu/%llu\n",
-					level, btrfs_qgroup_subvolid(entry->qgroupid));
-			args.qgroupid = entry->qgroupid;
-			ret = ioctl(fd, BTRFS_IOC_QGROUP_CREATE, &args);
-			if (ret < 0) {
-				error("cannot delete qgroup %llu/%llu: %m",
-					level,
-					btrfs_qgroup_subvolid(entry->qgroupid));
-			}
-		}
+		delete_ret = delete_one_stale_qgroup(&qgroup_lookup, entry, fd);
+		if (delete_ret < 0 && !ret)
+			ret = delete_ret;
 		node = rb_next(node);
 	}
 

--- a/kernel-shared/print-tree.c
+++ b/kernel-shared/print-tree.c
@@ -211,19 +211,28 @@ static void bg_flags_to_str(u64 flags, char *ret)
 	}
 }
 
-/* Caller should ensure sizeof(*ret)>= 26 "OFF|SCANNING|INCONSISTENT" */
+/*
+ * Caller should ensure sizeof(*ret)>= 64
+ * "OFF|SCANNING|INCONSISTENT|UNKNOWN(0xffffffffffffffff)"
+ */
 static void qgroup_flags_to_str(u64 flags, char *ret)
 {
 	ret[0] = 0;
+
 	if (flags & BTRFS_QGROUP_STATUS_FLAG_ON)
 		strcpy(ret, "ON");
 	else
 		strcpy(ret, "OFF");
 
+	if (flags & BTRFS_QGROUP_STATUS_FLAG_SIMPLE_MODE)
+		strcat(ret, "|SIMPLE_MODE");
 	if (flags & BTRFS_QGROUP_STATUS_FLAG_RESCAN)
 		strcat(ret, "|SCANNING");
 	if (flags & BTRFS_QGROUP_STATUS_FLAG_INCONSISTENT)
 		strcat(ret, "|INCONSISTENT");
+	if (flags & ~BTRFS_QGROUP_STATUS_FLAGS_MASK)
+		sprintf(ret + strlen(ret), "|UNKNOWN(0x%llx)",
+			flags & ~BTRFS_QGROUP_STATUS_FLAGS_MASK);
 }
 
 void print_chunk_item(struct extent_buffer *eb, struct btrfs_chunk *chunk)


### PR DESCRIPTION
Currently the `<stale>` label is give incorrectly for a lot of qgroups
that can not and should not be deleted.

The patchset would address the problem for `btrfs qgroup show` and
`btrfs qgroup clear-stale` commands, so that:

- `clear-stale` would not try to delete incorrect qgroups
  Thus it should not return false errors.

- `show` would show extra types of qgroups
  Including `<under deletion>` and `<squota space holder>`