### PR TITLE
btrfs-progs: docs: Clarify btrfs-send checksum

### DIFF
--- a/Documentation/Send-receive.rst
+++ b/Documentation/Send-receive.rst
@@ -20,5 +20,5 @@ The stream is a sequence of encoded commands that change e.g. file metadata
 (owner, permissions, extended attributes), data extents (create, clone,
 truncate), whole file operations (rename, delete). The stream can be sent over
 network, piped directly to the receive command or saved to a file. Each command
-in the stream is protected by a CRC32C checksum. See :doc:`btrfs-send`
+in the stream is protected by a CRC32C checksum, with 0 as the initial value and no inversion. See :doc:`btrfs-send`
 and :doc:`btrfs-receive` for more.


### PR DESCRIPTION
The way the CRC32C checksum used for btrfs-send differs from the way it's used elsewhere in btrfs. Without making the distinction, it's easy to make the flawed assumption that CRC32C always refers to the same, and end up with code that produces the wrong checksums.

This small note should guide the reader to the right function.

* * *

The best notes on the protocol I found are here:

https://archive.kernel.org/oldwiki/btrfs.wiki.kernel.org/index.php/Design_notes_on_Send/Receive.html

Reading "crc32", I thought it was easy to implement. Long story short I learned a lot more about CRC than I wanted. After bouncing around between different implementations claiming to be "the BTRFS one", I found that there are *two* ways to use CRC32C in btrfs.

Debugging a hash function is a trial-and-error affair, because you can hardly deduce which input was wrong, so you can never be sure if you actually made a subtle mistake or used the wrong algorithm whatsoever. So with the next person in mind, this commit reveals the mystery in the docs: yes, it's the same algorithm. Those two parameters are the ones which differ.

Rust code describing the algorithm for the [crc crate](https://github.com/mrhooray/crc-rs) that worked for me:

```
pub const CRC_32_BTRFS_SEND: crc::Algorithm<u32> = crc::Algorithm { width: 32, poly: 0x1edc6f41, init: 0, refin: true, refout: true, xorout: 0, check: 0xe3069283, residue: 0xb798b438 };
```

(it's a slight variation on the one used in ISCSI)