### PR TITLE
Misc/055 fix

### DIFF
--- a/tests/misc-tests/055-qgroup-clear-stale/test.sh
+++ b/tests/misc-tests/055-qgroup-clear-stale/test.sh
@@ -18,14 +18,15 @@ run_check $SUDO_HELPER "$TOP/btrfs" qgroup show "$TEST_MNT"
 rootid=$(run_check_stdout "$TOP/btrfs" inspect-internal rootid "$TEST_MNT/subv1")
 run_check $SUDO_HELPER "$TOP/btrfs" subvolume delete "$TEST_MNT/subv1"
 run_check $SUDO_HELPER "$TOP/btrfs" qgroup show "$TEST_MNT"
-# Subvolume deletion could be slow and won't let the qgroup to be cleaned,
-# shown as '<under deletion>'.
-if ! run_mayfail $SUDO_HELPER "$TOP/btrfs" qgroup clear-stale "$TEST_MNT"; then
-	run_check $SUDO_HELPER "$TOP/btrfs" subvolume sync "$TEST_MNT" "$rootid"
-	run_check $SUDO_HELPER "$TOP/btrfs" qgroup show "$TEST_MNT"
-	# After cleaning the subvolume it must pass
-	run_check $SUDO_HELPER "$TOP/btrfs" qgroup clear-stale "$TEST_MNT"
-fi
+
+# Subvolume under deletion won't be deleted and "btrfs qgroup clear-stale"
+# would detect it and not report an error.
+# So here we have to wait for the subvolume deletion.
+run_check $SUDO_HELPER "$TOP/btrfs" subvolume sync "$TEST_MNT" "$rootid"
+run_check $SUDO_HELPER "$TOP/btrfs" qgroup show "$TEST_MNT"
+# After cleaning the subvolume it must pass
+run_check $SUDO_HELPER "$TOP/btrfs" qgroup clear-stale "$TEST_MNT"
+
 list=$(run_check_stdout $SUDO_HELPER "$TOP/btrfs" qgroup show "$TEST_MNT")
 if echo "$list" | grep -q "0/$rootid"; then
 	_fail "stale qgroups not deleted"


### PR DESCRIPTION
[BUG]
There is a random chance that misc/055 would fail with stale qgroups
detected.

[CAUSE]
Commit 82f7d6c1d711 ("btrfs-progs: qgroup: handle stale qgroup deletion
more accurately") changed the behavior of "btrfs qgroup clear-stale"
that it will no longer try to remove qgroup undert deletion.

And the test case itself relies on the return value of "btrfs qgroup
clear-stale" to do the extra wait for subvolume deletion.

This means after that commit, the test case would skip the wait if there
is a subvolume waiting for cleanup, result a race window where the
subvolume can be dropped and become stale, and eventually trigger the
stale qgroup detection and cause false alerts.

[FIX]
Fix the test case by always wait for the subvolume to be dropped, so
that later "btrfs qgroup clear-stale" can properly remove all staled
qgroups.