### PR TITLE
btrfs-progs: fix csum metadata reservation and add a basic test case for it

### DIFF
--- a/tests/misc-tests/064-csum-conversion-basic/test.sh
+++ b/tests/misc-tests/064-csum-conversion-basic/test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Verify the csum conversion works as expected.
+#
+source "$TEST_TOP/common" || exit
+source "$TEST_TOP/common.convert" || exit
+
+check_experimental_build
+setup_root_helper
+prepare_test_dev
+
+convert_to_csum()
+{
+	local new_csum=$1
+
+	run_check "$TOP/btrfstune" --csum "$new_csum" "$TEST_DEV"
+	run_check "$TOP/btrfs" check --check-data-csum "$TEST_DEV"
+}
+
+run_check_mkfs_test_dev --csum crc32c
+
+# We only mount the fs once to populate its contents,
+# later one we would never mount the fs (to reduce the dependency on
+# kernel features).
+run_check_mount_test_dev
+populate_fs
+run_check_umount_test_dev
+
+convert_to_csum xxhash
+convert_to_csum blake2
+convert_to_csum sha256
+convert_to_csum crc32c

--- a/tune/change-csum.c
+++ b/tune/change-csum.c
@@ -224,14 +224,26 @@ out:
  * item.
  */
 #define CSUM_CHANGE_BYTES_THRESHOLD	(SZ_2M)
+
+static unsigned int calc_csum_change_nr_items(struct btrfs_fs_info *fs_info,
+					      u16 new_csum_type)
+{
+	const u32 new_csum_size = btrfs_csum_type_size(new_csum_type);
+	const u32 csum_item_size = CSUM_CHANGE_BYTES_THRESHOLD /
+				   fs_info->sectorsize * new_csum_size;
+
+	return round_up(csum_item_size, fs_info->nodesize) / fs_info->nodesize * 2;
+}
+
 static int generate_new_data_csums_range(struct btrfs_fs_info *fs_info, u64 start,
 					 u16 new_csum_type)
 {
+	const unsigned int nr_items = calc_csum_change_nr_items(fs_info,
+								new_csum_type);
 	struct btrfs_root *csum_root = btrfs_csum_root(fs_info, 0);
 	struct btrfs_trans_handle *trans;
 	struct btrfs_path path = { 0 };
 	struct btrfs_key key;
-	const u32 new_csum_size = btrfs_csum_type_size(new_csum_type);
 	void *csum_buffer;
 	u64 converted_bytes = 0;
 	u64 last_csum;
@@ -248,9 +260,7 @@ static int generate_new_data_csums_range(struct btrfs_fs_info *fs_info, u64 star
 	if (!csum_buffer)
 		return -ENOMEM;
 
-	trans = btrfs_start_transaction(csum_root,
-			CSUM_CHANGE_BYTES_THRESHOLD / fs_info->sectorsize *
-			new_csum_size);
+	trans = btrfs_start_transaction(csum_root, nr_items);
 	if (IS_ERR(trans)) {
 		ret = PTR_ERR(trans);
 		errno = -ret;
@@ -306,9 +316,7 @@ static int generate_new_data_csums_range(struct btrfs_fs_info *fs_info, u64 star
 				return -EUCLEAN;
 			if (ret < 0)
 				goto out;
-			trans = btrfs_start_transaction(csum_root,
-					CSUM_CHANGE_BYTES_THRESHOLD /
-					fs_info->sectorsize * new_csum_size);
+			trans = btrfs_start_transaction(csum_root, nr_items);
 			if (IS_ERR(trans)) {
 				ret = PTR_ERR(trans);
 				goto out;


### PR DESCRIPTION

The current csum conversion is using an incorrect parameter for
btrfs_start_transaction(), which is 16K times larger than the expected
metadata space, thus it always fail with -ENOSPC.

Fix that first, then add a basic test case using the same populate_fs()
from convert test cases, and iterate through all the support csum
algorithms.