### PR TITLE
btrfs-progs: tests: fix the mount failure detection

### DIFF
--- a/tests/common
+++ b/tests/common
@@ -238,7 +238,7 @@ run_check()
 
 	"${cmd_array[@]}" >> "$RESULTS" 2>&1
 	if [ "$?" -ne 0 ]; then
-		if cat "${cmd_array[@]}" | grep -q mount; then
+		if echo "${cmd_array[@]}" | grep -q mount; then
 			dmesg | tail -n 15 >> "$RESULTS"
 		fi
 		_fail "failed: ${cmd_array[@]}"


### PR DESCRIPTION
This fix should be folded into the offending one.

I'll do a rebase-and-merge first, then fold it locally, then a forced push.