### PR TITLE
btrfs-progs: scrub status: with --si, show rate in metric units

### DIFF
--- a/cmds/scrub.c
+++ b/cmds/scrub.c
@@ -220,10 +220,10 @@ static void print_scrub_summary(struct btrfs_scrub_progress *p, struct scrub_sta
 		pr_verbose(LOG_DEFAULT, "\n");
 	} else {
 		pr_verbose(LOG_DEFAULT, "Rate:             %s/s",
-			pretty_size(bytes_per_sec));
+			pretty_size_mode(bytes_per_sec, unit_mode));
 		if (limit > 1)
 			pr_verbose(LOG_DEFAULT, " (limit %s/s)",
-				   pretty_size(limit));
+				   pretty_size_mode(limit, unit_mode));
 		else if (limit == 1)
 			pr_verbose(LOG_DEFAULT, " (some device limits set)");
 		pr_verbose(LOG_DEFAULT, "\n");


### PR DESCRIPTION
This makes `btrfs scrub status --si` show the `Rate` in metric units as well.

before:

```
Total to scrub:   877.65GB
Rate:             609.22MiB/s
```

after:

```
Total to scrub:   877.65GB
Rate:             638.81MB/s
```