### PR TITLE
DOC: remove stated restriction that swapfile must be on a single device FS

### DIFF
--- a/.github/workflows/devel.yml
+++ b/.github/workflows/devel.yml
@@ -28,7 +28,17 @@ jobs:
         run: ./autogen.sh && CC=${{ matrix.compiler }} ./configure
       - name: Documentation
         run: make V=1 -C Documentation
-      - name: Generate manual pages preview
+      - name: Generate manual pages preview (html)
+        if: ${{ matrix.compiler == 'gcc' }}
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        run: |
+          for file in ${ALL_CHANGED_FILES}; do
+            echo "$file was changed, generate preview to summary"
+            Documentation/html-preview.sh "$file" >> $GITHUB_STEP_SUMMARY
+          done
+      - run: echo '<hr>' >> $GITHUB_STEP_SUMMARY
+      - name: Generate manual pages preview (man)
         if: ${{ matrix.compiler == 'gcc' }}
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}

--- a/Documentation/btrfs-inspect-internal.rst
+++ b/Documentation/btrfs-inspect-internal.rst
@@ -228,6 +228,9 @@ tree-stats [options] <device>
         -b
                 Print raw numbers in bytes.
 
+        -t <treeid>
+                Print stats only for the given treeid.
+
 EXIT STATUS
 -----------
 

--- a/Documentation/ch-swapfile.rst
+++ b/Documentation/ch-swapfile.rst
@@ -6,7 +6,8 @@ restrictions for active swapfiles don't apply.
 There are some limitations of the implementation in BTRFS and Linux swap
 subsystem:
 
-* filesystem - must be only single device
+* filesystem - should be only single device (depending on setup might not work
+  on multiple)
 * filesystem - must have only *single* data profile
 * subvolume - cannot be snapshotted if it contains any active swapfiles
 * swapfile - must be preallocated (i.e. no holes)

--- a/Documentation/html-preview.sh
+++ b/Documentation/html-preview.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Generate manual page preview as rendered by 'make html', removed some styling
+# so there can be visual artifacts, usable for CI summary
+
+if ! [ -f "$1" ]; then
+	exit 0
+fi
+
+prefix=Documentation/
+here=$(pwd)
+
+if [ "$(basename \"$here\")" = 'Documentation' ]; then
+	prefix=
+fi
+
+fn="$1"
+bn=$(basename "$fn" .rst)
+html=$(find "${prefix}"_build/html -name "$bn".'html')
+
+if ! [ -f "$html" ]; then
+	#echo "ERROR: cannot find html page '$html' from bn $bn fn $fn <br/>"
+	exit 0
+fi
+
+cat << EOF
+<details>
+<summary>$fn</summary>
+
+EOF
+
+# Up to <div itemprop="articleBody">, before that there's left bar navigation
+
+cat "$html" | sed -e 's/^\s\+//' | awk '
+/^<div itemprop=.articleBody.>/ { doit=1; next; }
+/^<\/body>/ { doit=0; next; }
+doit==1 { print; }'
+
+cat << EOF
+
+</details>
+EOF


### PR DESCRIPTION
Seems to work fine as long as DATA profile is "single"

    # cat /proc/swaps
    Filename				Type		Size		Used		Priority
    /mnt/backup/swap.10G                    file		10485756	0		-2

    # btrfs fi usage /mnt/backup
    Overall:
        Device size:		 254.67TiB
        Device allocated:		 182.03TiB
        Device unallocated:		  72.64TiB
        Device missing:		     0.00B
        Device slack:		     0.00B
        Used:			 181.49TiB
        Free (estimated):		  72.81TiB	(min: 36.49TiB)
        Free (statfs, df):		  72.81TiB
        Data ratio:			      1.00
        Metadata ratio:		      2.00
        Global reserve:		 512.00MiB	(used: 0.00B)
        Multiple profiles:		        no

    Data,single: Size:178.52TiB, Used:178.35TiB (99.91%)
       /dev/mapper/vg_backup-lv_backup	 118.58TiB
       /dev/md17	  59.95TiB

    Metadata,RAID1: Size:1.75TiB, Used:1.57TiB (89.48%)
       /dev/mapper/vg_backup-lv_backup	   1.75TiB
       /dev/md17	   1.75TiB

    System,RAID1: Size:32.00MiB, Used:21.41MiB (66.89%)
       /dev/mapper/vg_backup-lv_backup	  32.00MiB
       /dev/md17	  32.00MiB

    Unallocated:
       /dev/mapper/vg_backup-lv_backup	  61.58TiB
       /dev/md17	  11.06TiB