### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix few typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git*,*.svg,*.css,.codespellrc
+check-hidden = true
+# ignore-regex = 
+# ignore-words-list =

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,6 +1,8 @@
 [codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = .git*,*.svg,*.css,.codespellrc
+skip = .git*,*.svg,*.css,.codespellrc,fsck-tests
 check-hidden = true
-# ignore-regex = 
-# ignore-words-list =
+ignore-regex = \b(Yann Collet|TOI)\b
+# annote - used as a noun
+# iput - function name
+ignore-words-list = annote,annotes,iput,uptodate

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [devel]
+  pull_request:
+    branches: [devel]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@
 !.editorconfig
 !.github
 !.readthedocs.yaml
+!.codespellrc
 
 /ci/images/*/devel.tar.gz
 

--- a/CHANGES
+++ b/CHANGES
@@ -1689,7 +1689,7 @@ btrfs-progs-4.4 (2016-01-18)
 
   Bugfixes:
      * chunk recovery: fix floating point exception
-     * chunk recovery: endianity bugfix during rebuild
+     * chunk recovery: endianness bugfix during rebuild
      * mkfs with 64K pages and nodesize reported superblock checksum mismatch
      * check: properly reset nlink of multi-linked file
 

--- a/Documentation/Custom-ioctls.rst
+++ b/Documentation/Custom-ioctls.rst
@@ -20,5 +20,5 @@ a command if available:
 
 - query/set a subset of features on a mounted filesystem
 
-Programming documentaion of the ioctls is in the manual page
+Programming documentation of the ioctls is in the manual page
 :doc:`btrfs-ioctl`.

--- a/Documentation/DocConventions.rst
+++ b/Documentation/DocConventions.rst
@@ -18,7 +18,7 @@ Manual pages structure:
 -  subcommands are in alphabetical order
 
 -  long command output or shell examples: verbatim output
-   -  use ``..code-block::`` directive with ``bash`` or ``plain`` syntax hilighting
+   -  use ``..code-block::`` directive with ``bash`` or ``plain`` syntax highlighting
 
 Quotes, reference, element formatting:
 

--- a/Documentation/Feature-by-version.rst
+++ b/Documentation/Feature-by-version.rst
@@ -331,7 +331,7 @@ features see :doc:`Status<Status>` page.
         Improved implementation of free space cache (aka v2), using b-trees.
 
         .. note::
-           Default since btrfs-progs 5.15, Kernel 4.9 fixes endianity bugs on
+           Default since btrfs-progs 5.15, Kernel 4.9 fixes endianness bugs on
            big-endian machines, x86* is ok
 
 4.5 - balance filter updates

--- a/Documentation/Kernel-by-version.rst
+++ b/Documentation/Kernel-by-version.rst
@@ -577,7 +577,7 @@ Pull requests:
 `v5.0-rc3 <https://git.kernel.org/linus/1be969f4682b0aa1995e46fba51502de55f15ce8>`__,
 `v5.0-rc5 <https://git.kernel.org/linus/312b3a93dda6db9354b0c6b0f1868c1434e8c787>`__
 
-Features, hilights:
+Features, highlights:
 
 - swapfile support (with some limitations)
 - metadata uuid - new feature that allows fast uuid change without rewriting all metadata blocks (backward incompatible)
@@ -609,7 +609,7 @@ Pull requests:
 `v5.1-rc5 <https://git.kernel.org/linus/2d06b235815e6bd20395f3db9ada786a6f7a876e>`__,
 `v5.1-rc7 <https://git.kernel.org/linus/d0473f978e61557464daa8547008fa2cd0c63a17>`__
 
-New features, hilights:
+New features, highlights:
 
 - zstd compression levels can be set as mount options
 - new ioctl to unregister scanned devices
@@ -634,7 +634,7 @@ Pull requests:
 `v5.2-rc5 <https://git.kernel.org/linus/6fa425a2651515f8d262f2c1d972c6632e7c941d>`__,
 `v5.2-rc6 <https://git.kernel.org/linus/bed3c0d84e7e25c8e0964d297794f4c215b01f33>`__
 
-User visible changes, hilights:
+User visible changes, highlights:
 
 - better read time and write checks to catch errors early and before writing data to disk
 - qgroups + metadata relocation: last speed up patch in the series there should
@@ -672,7 +672,7 @@ Pull requests:
 `v5.3-rc5 <https://git.kernel.org/linus/3039fadf2bfdc104dc963820c305778c7c1a6229>`__,
 `v5.3 <https://git.kernel.org/linus/1b304a1ae45de4df7d773f0a39d1100aabca615b>`__
 
-New features, hilights:
+New features, highlights:
 
 - chunks that have been trimmed and unchanged since last mount are tracked and skipped on repeated trims
 - use hw assisted crc32c on more arches
@@ -762,7 +762,7 @@ Highlights:
 - async discard
 
   - "mount -o discard=async" to enable it
-  - freed extents are not discarded immediatelly, but grouped together and
+  - freed extents are not discarded immediately, but grouped together and
     trimmed later, with IO rate limiting
   - the actual discard IO requests have been moved out of transaction commit
     to a worker thread, improving commit latency
@@ -780,7 +780,7 @@ Core changes:
   that was confusing
 - device closing does not need to allocate memory anymore
 - snapshot aware code got removed, disabled for years due to performance
-  problems, reimplmentation will allow to select wheter defrag breaks or does
+  problems, reimplementation will allow to select whether defrag breaks or does
   not break COW on shared extents
 - tree-checker:
 
@@ -805,14 +805,14 @@ Pull requests:
 `v5.7-rc4 <https://git.kernel.org/linus/51184ae37e0518fd90cb437a2fbc953ae558cd0d>`__,
 `v5.7-rc4 <https://git.kernel.org/linus/262f7a6b8317a06e7d51befb690f0bca06a473ea>`__
 
-Hilights:
+Highlights:
 
 - v2 of ioctl to delete subvolumes, allowing to delete by id and more future extensions
 - removal of obsolete ioctl flag BTRFS_SUBVOL_CREATE_ASYNC
 - more responsive balance cancel
 - speedup of extent back reference resolution
 - reflink/clone_range works on inline extents
-- lots of othe core changes, see the [https://git.kernel.org/linus/15c981d16d70e8a5be297fa4af07a64ab7e080ed pull request]
+- lots of other core changes, see the [https://git.kernel.org/linus/15c981d16d70e8a5be297fa4af07a64ab7e080ed pull request]
 
 5.8 (Aug 2020)
 ^^^^^^^^^^^^^^
@@ -825,7 +825,7 @@ Pull requests:
 `v5.8-rc5 <https://git.kernel.org/linus/72c34e8d7099c329c2934c2ac9c886f638b6edaf>`__,
 `v5.8-rc7 <https://git.kernel.org/linus/0669704270e142483d80cfda5c526426c1a89711>`__
 
-Hilights:
+Highlights:
 
 - speedup dead root detection during orphan cleanup
 - send will emit file capabilities after chown
@@ -850,7 +850,7 @@ Pull requests:
 `v5.9-rc7 <https://git.kernel.org/linus/bffac4b5435a07bf26604385ae533adff3cccf23>`__,
 `v5.9-rc8 <https://git.kernel.org/linus/4e3b9ce271b4b54d2293a3916d22e4ddc0c89aab>`__
 
-Hilights:
+Highlights:
 
 - add mount option ''rescue'' to unify options for various recovery tasks on a mounted filesystems
 - mount option ''inode_cache'' is deprecated and will be removed in 5.11
@@ -870,7 +870,7 @@ Pull requests:
 `v5.10-rc4 <https://git.kernel.org/linus/e2f0c565ec70eb9e4d3b98deb5892af62de8b98d>`__,
 `v5.10-rc6 <https://git.kernel.org/linus/a17a3ca55e96d20e25e8b1a7cd08192ce2bac3cc>`__
 
-Hilights:
+Highlights:
 
 - performance improvements in fsync (dbench workload: higher throughput, lower latency)
 - sysfs exports current exclusive operataion (balance, resize, device add/del/...)
@@ -999,7 +999,7 @@ Pull requests:
 `v5.14-rc7 <https://git.kernel.org/linus/d6d09a6942050f21b065a134169002b4d6b701ef>`__,
 `v5.14 <https://git.kernel.org/linus/9b49ceb8545b8eca68c03388a07ecca7caa5d9c1>`__
 
-Hilights:
+Highlights:
 
 - new sysfs knob to limit scrub IO bandwidth per device
 - device stats are also available in /sys/fs/btrfs/FSID/devinfo/DEVID/error_stats
@@ -1195,7 +1195,7 @@ Core, fixes:
 
 - prevent deleting subvolume with active swapfile
 - remove device count in superblock and its item in one transaction so
-  they cant't get out of sync
+  they can't get out of sync
 - for subpage, force the free space v2 mount to avoid a warning and
   make it easy to switch a filesystem on different page size systems
 - export sysfs status of exclusive operation 'balance paused', so the
@@ -1390,7 +1390,7 @@ Fixes:
 Fixes:
 
 - device delete hang at the end of the operation
-- free space tree bitmap endianity fixed on big-endian machines
+- free space tree bitmap endianness fixed on big-endian machines
 - parallel incremental send and balance issue fixed
 - cloning ioctl can be interrupted by a fatal signal
 - other stability fixes or cleanups
@@ -1398,7 +1398,7 @@ Fixes:
 4.10 (Feb 2017)
 ^^^^^^^^^^^^^^^
 
-- balance: human readable block group descripion in the log
+- balance: human readable block group description in the log
 - balance: fix storing of stripes_min, stripes_max filters to the on-disk item
 - qgroup: fix accounting bug during concurrent balance run
 - better worker thread resource limit checks
@@ -1555,7 +1555,7 @@ Internal changes:
 4.19 (Oct 2018)
 ^^^^^^^^^^^^^^^
 
-Hilights, no big changes in this releaase:
+Highlights, no big changes in this release:
 
 - allow defrag on opened read-only files that have rw permissions
 - tree checker improvements, reported by fuzzing

--- a/Documentation/btrfs-ioctl.rst
+++ b/Documentation/btrfs-ioctl.rst
@@ -728,7 +728,7 @@ BTRFS_IOC_SUBVOL_CREATE_V2
      - ignored
    * - args.flags
      - flags to set on the subvolume, ``BTRFS_SUBVOL_RDONLY`` for readonly,
-       ``BTRFS_SUBVOL_QGROUP_INHERIT`` if the qgroup related fileds should be
+       ``BTRFS_SUBVOL_QGROUP_INHERIT`` if the qgroup related fields should be
        processed
    * - args.size
      - number of entries in ``args.qgroup_inherit``

--- a/Documentation/dev/Developer-s-FAQ.rst
+++ b/Documentation/dev/Developer-s-FAQ.rst
@@ -56,7 +56,7 @@ as a reply to the mailinglist after you've reviewed a patch. See below.
 Reviewed-by:
 ^^^^^^^^^^^^
 
-The patch has been reviewed and the singed person is putting his hand into
+The patch has been reviewed and the signed person is putting his hand into
 fire. If there's a bug found in this patch, the person is usually a good
 candidate for a CC: of the bugreport.
 
@@ -157,7 +157,7 @@ Controversial changes
 This happens, not every patch gets merged. In the worst case there are not even
 any comments under the patch and it's silently ignored. This depends on many
 factors, most notably \*cough*time*cough*. Examining potential drawbacks or
-forseeing disasters is not an easy job.
+foreseeing disasters is not an easy job.
 
 Let's be more positive, you manage to attract the attention of some developer
 and he says, he does not like the approach of the patch(es).  Better than

--- a/Documentation/dev/Development-notes.rst
+++ b/Documentation/dev/Development-notes.rst
@@ -239,7 +239,7 @@ Patches
 
 -  additional information
 
-    -  if there's a stack trace relevant for the patch, add it ther (lockdep,
+    -  if there's a stack trace relevant for the patch, add it there (lockdep,
        crash, warning)
     -  steps to reproduce a bug (that will also get turned to a proper fstests
        case)

--- a/Documentation/man-preview.sh
+++ b/Documentation/man-preview.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Generate manual page preview as rendered to a terminal, without colors or
-# text attributes, encapsualted html, usable for CI summary
+# text attributes, encapsulated html, usable for CI summary
 
 if ! [ -f "$1" ]; then
 	exit 0

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ some architectures.  Optionally it's possible to use
 [Botan](https://botan.randombit.net) or
 [OpenSSL](https://www.openssl.org) implementations.
 
-The builtin implemtations uses the following sources:
+The builtin implementations uses the following sources:
 [CRC32C](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git),
 [XXHASH](https://github.com/Cyan4973/xxHash),
 [SHA256](https://tools.ietf.org/html/rfc4634),

--- a/btrfs-debugfs
+++ b/btrfs-debugfs
@@ -336,7 +336,7 @@ def print_block_groups(mountpoint):
         p_left = args_buffer_size
 
         for _ in range(0, s.args.nr_items):
-            # for each itme, copy the header from the buffer into
+            # for each item, copy the header from the buffer into
             # our header struct
             ctypes.memmove(h, p, header_size)
             p += header_size

--- a/ci/images/images-base-update
+++ b/ci/images/images-base-update
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Update all base images from Dockefile
+# Update all base images from Dockerfile
 # Run before: images-build-all
 
 for dir in ci-*; do

--- a/cmds/filesystem.c
+++ b/cmds/filesystem.c
@@ -1331,7 +1331,7 @@ static int check_resize_args(const char *amount, const char *path, u64 *devid_re
 		goto out;
 	} else if (!devstr && devid == 1 && dev_idx < 0) {
 		/*
-		 * No device specified, assuming implicit 1 but it doess not
+		 * No device specified, assuming implicit 1 but it does not
 		 * exist. Use minimum device as fallback.
 		 */
 		warning("no devid specified means devid 1 which does not exist, using\n"

--- a/cmds/inspect.c
+++ b/cmds/inspect.c
@@ -839,7 +839,7 @@ static int print_list_chunks(struct list_chunks_ctx *ctx, const char *sortmode,
 		  .id = CHUNK_SORT_USAGE
 		},
 		{ .name = "length", .comp = (sort_cmp_t)cmp_cse_length,
-		  .desc = "sort by lentgh",
+		  .desc = "sort by length",
 		  .id = CHUNK_SORT_LENGTH
 		},
 		SORTDEF_END
@@ -876,7 +876,7 @@ static int print_list_chunks(struct list_chunks_ctx *ctx, const char *sortmode,
 		ctx->stats[i].pnumber = number++;
 	}
 
-	/* Skip additonal sort if nothing defined by user. */
+	/* Skip additional sort if nothing defined by user. */
 	if (comp.count > 0)
 		qsort_r(ctx->stats, ctx->length, sizeof(ctx->stats[0]),
 			(sort_r_cmp_t)compare_cmp_multi, &comp);

--- a/common/array.c
+++ b/common/array.c
@@ -80,7 +80,7 @@ void array_use_capacity(struct array *arr)
 	arr->length = arr->capacity;
 }
 
-/* Append a new element (increas length), extend the array if needed. */
+/* Append a new element (increase length), extend the array if needed. */
 int array_append(struct array *arr, void *element)
 {
 	if (arr->length == arr->capacity) {

--- a/common/send-stream.c
+++ b/common/send-stream.c
@@ -131,7 +131,7 @@ static int read_cmd(struct btrfs_send_stream *sctx)
 		goto out;
 	}
 
-	/* The read_buf does not guarantee any aligmnet for any structures. */
+	/* The read_buf does not guarantee any alignment for any structures. */
 	cmd_hdr = (struct btrfs_cmd_header *)sctx->read_buf;
 	cmd_len = get_unaligned_le32(&cmd_hdr->len);
 	cmd = get_unaligned_le16(&cmd_hdr->cmd);

--- a/common/sort-utils.c
+++ b/common/sort-utils.c
@@ -93,7 +93,7 @@ int compare_add_sort_id(struct compare *comp, int id)
  *
  * Key lookup is case insensitive.
  *
- * Retrun: id from sortdef if a matching
+ * Return: id from sortdef if a matching
  *         -1 on error
  *         -2 end of buffer
  */

--- a/common/sort-utils.h
+++ b/common/sort-utils.h
@@ -44,7 +44,7 @@ void test() {
 	struct entry entries[SIZE];
 	// Comparator structure
 	struct compare comp = { 0 };
-	// Keys, item comparators, help text defitions
+	// Keys, item comparators, help text definitions
 	struct sortdef sortit[] = {
 		{ .name = "id",   .comp = (sort_cmp_t)cmp_entry_id,
 		  .desc = "sort by id" },

--- a/convert/source-ext2.c
+++ b/convert/source-ext2.c
@@ -62,7 +62,7 @@ static int ext2_open_fs(struct btrfs_convert_context *cctx, const char *name)
 	/*
 	 * We need to know exactly the used space, some RO compat flags like
 	 * BIGALLOC will affect how used space is present.
-	 * So we need manuall check any unsupported RO compat flags
+	 * So we need manually check any unsupported RO compat flags
 	 */
 	ro_feature = ext2_fs->super->s_feature_ro_compat;
 	if (ro_feature & ~EXT2_LIB_FEATURE_RO_COMPAT_SUPP) {

--- a/crypto/crc32c-pcl-intel-asm_64.S
+++ b/crypto/crc32c-pcl-intel-asm_64.S
@@ -191,7 +191,7 @@ crc_pcl:
 	xor     crc1,crc1
 	xor     crc2,crc2
 
-	# Fall thruogh into top of crc array (crc_128)
+	# Fall through into top of crc array (crc_128)
 
 	################################################################
 	## 3) CRC Array:

--- a/crypto/crc32c.c
+++ b/crypto/crc32c.c
@@ -194,7 +194,7 @@ static const uint32_t crc32c_table[256] = {
 };
 
 /*
- * Fallback implementatin. Step through buffer one byte at at time, calculates
+ * Fallback implementation. Step through buffer one byte at at time, calculates
  * reflected crc using table, can accept an unaligned buffer.
  */
 static uint32_t crc32c_ref(uint32_t crc, unsigned char const *data, uint32_t length)

--- a/inject-error
+++ b/inject-error
@@ -32,7 +32,7 @@ for l in ch_lines:
         if not c in found:
             found[c] = fn + ":" + line
         else:
-            print(f"ERROR: cookie {c} in {fn}:{line} not uniqe, please fix it first")
+            print(f"ERROR: cookie {c} in {fn}:{line} not unique, please fix it first")
 
 if len(sys.argv) == 1:
     cookie = do_new_cookie()

--- a/kernel-shared/volumes.h
+++ b/kernel-shared/volumes.h
@@ -111,7 +111,7 @@ struct btrfs_fs_devices {
 
 	bool changing_fsid;
 	bool active_metadata_uuid;
-	/* Super block data may be temporarily inconsistent (e.g. a differnt fsid). */
+	/* Super block data may be temporarily inconsistent (e.g. a different fsid). */
 	bool inconsistent_super;
 };
 

--- a/mkfs/rootdir.c
+++ b/mkfs/rootdir.c
@@ -443,7 +443,7 @@ static int copy_rootdir_inode(struct btrfs_trans_handle *trans,
 	ret = stat(dir_name, &st);
 	if (ret < 0) {
 		ret = -errno;
-		error("stat failed for direcotry %s: %m", dir_name);
+		error("stat failed for directory %s: %m", dir_name);
 		return ret;
 	}
 

--- a/tests/array-test.c
+++ b/tests/array-test.c
@@ -25,7 +25,7 @@ static void test_simple_create()
 	int i;
 
 	array_init(&arr, 0);
-	printf("Create array with default intial capacity=%u\n", arr.capacity);
+	printf("Create array with default initial capacity=%u\n", arr.capacity);
 	array_append(&arr, (void *)0x1);
 	array_append(&arr, (void *)0x2);
 	array_append(&arr, (void *)0x3);
@@ -41,7 +41,7 @@ static void test_simple_alloc_elems()
 	const int count = 1000000;
 
 	array_init(&arr, 0);
-	printf("Create array with default intial capacity=%u\n", arr.capacity);
+	printf("Create array with default initial capacity=%u\n", arr.capacity);
 	for (i = 0; i < count; i++) {
 		char *tmp;
 		int ret;

--- a/tests/build-tests.sh
+++ b/tests/build-tests.sh
@@ -7,7 +7,7 @@
 # - various configure options
 #
 # Arguments:
-# - (first arugment) --ccache - enable ccache for build which can speed up
+# - (first argument) --ccache - enable ccache for build which can speed up
 #    rebuilding same files if the options do not affect them, the ccache will
 #    be created in the toplevel git directory
 # - anything else will be passed to 'make', eg. define CC, D, V

--- a/tests/check-setup.sh
+++ b/tests/check-setup.sh
@@ -4,7 +4,7 @@
 
 for dir in *-tests; do
 	missing=
-	echo "Checking prerequisities for: $dir"
+	echo "Checking prerequisites for: $dir"
 	for prog in $(find "$dir" -name 'test.sh' -exec grep check_global_prereq '{}' \; | sort -u); do
 		if [ "$prog" = check_global_prereq ]; then
 			continue

--- a/tests/common
+++ b/tests/common
@@ -431,7 +431,7 @@ check_global_prereq()
 {
 	type -p "$1" &> /dev/null
 	if [ $? -ne 0 ]; then
-		_fail "Failed system wide prerequisities: $1";
+		_fail "Failed system wide prerequisites: $1";
 	fi
 }
 


### PR DESCRIPTION
I think I have used btrfs-progs directly or not (via btrbk) for years... finally got a motivation/trigger to contribute ;)

More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.