### PR TITLE
btrfs-progs: add uClibc-ng compatibility for printf format %pV

### DIFF
--- a/.github/workflows/devel.yml
+++ b/.github/workflows/devel.yml
@@ -28,7 +28,17 @@ jobs:
         run: ./autogen.sh && CC=${{ matrix.compiler }} ./configure
       - name: Documentation
         run: make V=1 -C Documentation
-      - name: Generate manual pages preview
+      - name: Generate manual pages preview (html)
+        if: ${{ matrix.compiler == 'gcc' }}
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        run: |
+          for file in ${ALL_CHANGED_FILES}; do
+            echo "$file was changed, generate preview to summary"
+            Documentation/html-preview.sh "$file" >> $GITHUB_STEP_SUMMARY
+          done
+      - run: echo '<hr>' >> $GITHUB_STEP_SUMMARY
+      - name: Generate manual pages preview (man)
         if: ${{ matrix.compiler == 'gcc' }}
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}

--- a/Documentation/btrfs-inspect-internal.rst
+++ b/Documentation/btrfs-inspect-internal.rst
@@ -228,6 +228,9 @@ tree-stats [options] <device>
         -b
                 Print raw numbers in bytes.
 
+        -t <treeid>
+                Print stats only for the given treeid.
+
 EXIT STATUS
 -----------
 

--- a/Documentation/html-preview.sh
+++ b/Documentation/html-preview.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Generate manual page preview as rendered by 'make html', removed some styling
+# so there can be visual artifacts, usable for CI summary
+
+if ! [ -f "$1" ]; then
+	exit 0
+fi
+
+prefix=Documentation/
+here=$(pwd)
+
+if [ "$(basename \"$here\")" = 'Documentation' ]; then
+	prefix=
+fi
+
+fn="$1"
+bn=$(basename "$fn" .rst)
+html=$(find "${prefix}"_build/html -name "$bn".'html')
+
+if ! [ -f "$html" ]; then
+	#echo "ERROR: cannot find html page '$html' from bn $bn fn $fn <br/>"
+	exit 0
+fi
+
+cat << EOF
+<details>
+<summary>$fn</summary>
+
+EOF
+
+# Up to <div itemprop="articleBody">, before that there's left bar navigation
+
+cat "$html" | sed -e 's/^\s\+//' | awk '
+/^<div itemprop=.articleBody.>/ { doit=1; next; }
+/^<\/body>/ { doit=0; next; }
+doit==1 { print; }'
+
+cat << EOF
+
+</details>
+EOF

--- a/common/messages.h
+++ b/common/messages.h
@@ -25,7 +25,9 @@
 /*
  * Workaround for custom format %pV that may not be supported on all libcs.
  */
-#ifdef HAVE_PRINTF_H
+#if defined(HAVE_PRINTF_H) \
+	&& defined(HAVE_REGISTER_PRINTF_SPECIFIER) \
+	&& defined(HAVE_REGISTER_PRINTF_MODIFIER)
 #define DECLARE_PV(name)		struct va_format name
 #define PV_FMT				"%pV"
 #define PV_VAL(va)			&va

--- a/configure.ac
+++ b/configure.ac
@@ -95,6 +95,10 @@ AC_CHECK_HEADERS([linux/hw_breakpoint.h])
 AC_CHECK_HEADERS([linux/fsverity.h])
 AC_CHECK_HEADERS([printf.h])
 
+dnl Check for printf.h functions.
+AC_CHECK_FUNCS([register_printf_specifier])
+AC_CHECK_FUNCS([register_printf_modifier])
+
 if grep -q 'HAVE_LINUX_FSVERITY_H.*1' confdefs.h; then
 	have_fsverity='yes'
 else


### PR DESCRIPTION
Commit [1] 164bc10d "btrfs-progs: add musl compatibility for printf format %pV" added a logic to detect the presence of the glibc <printf.h> header, and if present, to use the
register_printf_specifier() and register_printf_modifier() functions.

The original intent (as the commit log suggests), was to support the musl libc, which does not provides this <printf.h> header.

When compiling with another libc, such as uClibc-ng, btrfs-progs fail to build with error:

    common/messages.c: In function 'print_va_format':
    common/messages.c:51:19: error: 'const struct printf_info' has no member named 'user'
       51 |         if (!(info->user & va_modifier))
          |                   ^~
    common/messages.c: In function 'btrfs_no_printk':
    common/messages.c:76:17: warning: implicit declaration of function 'register_printf_specifier'; did you mean 'register_printf_function'? [-Wimplicit-function-declaration]
       76 |                 register_printf_specifier('V', print_va_format,
          |                 ^~~~~~~~~~~~~~~~~~~~~~~~~
          |                 register_printf_function
    common/messages.c:78:31: warning: implicit declaration of function 'register_printf_modifier'; did you mean 'register_printf_function'? [-Wimplicit-function-declaration]
       78 |                 va_modifier = register_printf_modifier(L"p");
          |                               ^~~~~~~~~~~~~~~~~~~~~~~~
          |                               register_printf_function

This is because uClibc-ng provides a <printf.h> header, but not the register_printf_specifier() and register_printf_modifier() functions. See [2]. It mainly includes register_printf_function(). uClibc-ng emulates an older glibc behavior. Glibc added support for printf user elements in commit [3] (first included in glibc-2.10, in 2009). Checking only the <printf.h> is not sufficient.

This commit fixes this build issue by refining the detection logic of the <printf.h> functions required by btrfs-progs.

[1] https://github.com/kdave/btrfs-progs/commit/164bc10dfc08d8754d23ef0d6d7281e139d6cd53
[2] https://gogs.waldemar-brodkorb.de/oss/uclibc-ng/src/v1.0.49/include/printf.h
[3] https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=9d26efa90c6dcbcd6b3e586c9927b6058ef4d529