### PR TITLE
btrfs-progs: convert: fix the rollback filename output

### DIFF
--- a/convert/main.c
+++ b/convert/main.c
@@ -1739,7 +1739,7 @@ static int do_rollback(const char *devname)
 	if (name_len > sizeof(dir_name))
 		name_len = sizeof(dir_name) - 1;
 	read_extent_buffer(path.nodes[0], dir_name, (unsigned long)(root_ref_item + 1), name_len);
-	dir_name[sizeof(dir_name) - 1] = 0;
+	dir_name[name_len] = 0;
 
 	printf("  Restoring from:  %s/%s\n", dir_name, image_name);
 

--- a/tests/convert-tests/026-rollback-output/test.sh
+++ b/tests/convert-tests/026-rollback-output/test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Make sure "btrfs-convert -r" is outputting the correct filename
+
+source "$TEST_TOP/common" || exit
+source "$TEST_TOP/common.convert" || exit
+
+setup_root_helper
+prepare_test_dev
+
+check_global_prereq mkfs.ext4
+check_prereq btrfs-convert
+check_prereq btrfs
+
+convert_test_prep_fs ext4 mke2fs -t ext4 -b 4096
+run_check_umount_test_dev
+convert_test_do_convert
+
+# Rollback and save the output.
+run_check_stdout "$TOP/btrfs-convert" --rollback "$TEST_DEV" |\
+	grep -q "ext2_saved/image" || _fail "rollback filename output is corruptedd"


### PR DESCRIPTION
When testing my newer version of subvolume creation cleanup (which
removes btrfs_mksubvol(), utilized by convert), I found out that
"btrfs-convert -r" output is always corrupted.

It turns out to be a small string termination problem.

The first patch fixes it, then a new test case for it.