### PR TITLE
Improve documentation around userspace tool behaviour and safety

### DIFF
--- a/Documentation/btrfs-check.rst
+++ b/Documentation/btrfs-check.rst
@@ -19,6 +19,12 @@ by the option *--readonly*.
 
 :command:`btrfsck` is an alias of :command:`btrfs check` command and is now deprecated.
 
+.. note::
+   Even though the filesystem checker requires a device argument, it scans for all
+   devices belonging to the same filesystem and may report metadata errors from other
+   devices that are correctable by :command:`btrfs scrub`. In this case, run scrub
+   first to ensure any correctable metadata errors are fixed to avoid false-positives.
+
 .. warning::
    Do not use *--repair* unless you are advised to do so by a developer
    or an experienced user, and then only after having accepted that no *fsck*

--- a/Documentation/ch-scrub-intro.rst
+++ b/Documentation/ch-scrub-intro.rst
@@ -17,7 +17,9 @@ from one of the other replicas.
    damage is detected by checksum validation and a mirror copy is used, but
    because ``No_COW`` files are not protected by checksum, bad data may be
    returned even if a good copy exists on another replica. Which replica is used
-   is based on the process ID of the executable reading the file.
+   is determined by the setting in ``/sys/fs/btrfs/<uuid>/read_policy``.
+   Currently, the only possible value for this setting is ``pid``, which uses
+   the process ID of the executable reading the file to pick the replica.
 
    Writing to a ``No_COW`` file after reading from a bad replica will overwrite
    all replicas with the bad data. Detecting and recovering from a failure in

--- a/Documentation/ch-volume-management-intro.rst
+++ b/Documentation/ch-volume-management-intro.rst
@@ -116,3 +116,20 @@ In order to remove a device, you need to convert the profile in this case:
 
         $ btrfs balance start -mconvert=dup -dconvert=single /mnt
         $ btrfs device remove /dev/sda /mnt
+
+.. warning::
+   Do not run balance to convert from a profile with more redundancy to one with
+   less redundancy in order to remove a failing device from a filesystem.
+   As the name suggests, balance tries to balance data across devices.
+   Converting from e.g. raid1 to single may move data from the healthy device to
+   the failing device. This data will become irretrievable if the failing device
+   corrupts the new data or fails completely before ``btrfs device remove`` can
+   finish moving it back onto the healthy device.
+
+   To recover from a failing device with a replicated profile when you cannot
+   add enough new devices to maintain the required level of redundancy,
+   physically remove and replace the failing device, mount the filesystem with
+   ``-o degraded``, then use :command:`btrfs-replace` to replace the missing
+   device with the new one. Once the device is replaced, check
+   ``btrfs filesystem usage``, and if any single profiles are listed, run
+   ``btrfs balance start convert=raid1,soft`` to convert them back to raid1.

--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -91,6 +91,11 @@ is in the :doc:`manual pages<man-index>`.
 
    </td></tr></table>
 
+Need help?
+----------
+
+Assistance is available from the `#btrfs channel on Libera Chat <https://web.libera.chat/#btrfs>`_ or the `linux-btrfs mailing list <https://subspace.kernel.org/vger.kernel.org.html>`_. Issues with the userspace btrfs tools can be reported to the `btrfs-progs issue tracker on GitHub <https://github.com/kdave/btrfs-progs/issues>`_.
+
 .. raw:: html
 
    <hr />


### PR DESCRIPTION
Hi there,

On the [mailing list](https://lore.kernel.org/linux-btrfs/02afb6b7-e566-474e-80ff-3ace99693553@zetafleet.com/T/) for the past few days I have been shouting into the void about some issues I encountered trying to deal with a hardware failure on a btrfs raid-1 filesystem. In my last mail I made several recommendations, and while I won’t be able to become familiar enough with the internals of the btrfs tools themselves to send patches for some of them, but I am at least capable of writing a few paragraphs of documentation. So, here are some patches for that.

In the scrub documentation change I made, I am not sure if there are other edge cases beyond the split-brain one I document where running scrub would be dangerous. I adapted the line about its safety from the comment at https://github.com/kdave/btrfs-progs/issues/816#issuecomment-2166698048. I think that comment probably contains more useful information that could be integrated into the documentation too, but I am currently out of energy to make additional changes.

I also think I may be documenting some bugs here, like that btrfs-check looks at metadata from some place other than the specified block device which seems like it should not be doing since it does not take a filesystem path, but at least I would prefer the current behaviour to be documented than to have one other person be shocked when they see errors that go away after a read-write scrub.

I hope these changes are helpful. Please feel free to change or adapt as necessary, I do not anticipate focusing much more on this right now because I have other obligations.

Thank you for writing and maintaining btrfs and I hope you have a great week!