### PR TITLE
btrfs-progs: add --default-subvol option to mkfs.btrfs

### DIFF
--- a/Documentation/mkfs.btrfs.rst
+++ b/Documentation/mkfs.btrfs.rst
@@ -160,6 +160,10 @@ OPTIONS
         directory.  The option *--rootdir* must also be specified, and *subdir* must be an
         existing subdirectory within it.  This option can be specified multiple times.
 
+--default-subvol <subdir>
+        As *--subvol*, except that it also sets the subvolume as the default for the
+        filesystem.  This option can only be specified once.
+
 --shrink
         Shrink the filesystem to its minimal size, only works with *--rootdir* option.
 

--- a/mkfs/rootdir.h
+++ b/mkfs/rootdir.h
@@ -32,6 +32,7 @@ struct rootdir_subvol {
 	struct list_head list;
 	char *dir;
 	char *full_path;
+	bool is_default;
 };
 
 int btrfs_mkfs_fill_dir(struct btrfs_trans_handle *trans, const char *source_dir,


### PR DESCRIPTION
Adds a --default-subvol option to mkfs.btrfs, which works the same way as --subvol but also marks the subvolume as the default.