### PR TITLE
btrfs-progs: mkfs/rootdir: add hard link support

### DIFF
--- a/Documentation/mkfs.btrfs.rst
+++ b/Documentation/mkfs.btrfs.rst
@@ -165,6 +165,19 @@ OPTIONS
         * *default*: create as default subvolume (this can only be specified once)
         * *ro*: create as readonly subvolume
 
+	If there are hard links inside *rootdir* and *subdir* will split the
+	subvolumes, like the following case::
+
+		rootdir/
+		|- hardlink1
+		|- hardlink2
+		|- subdir/  <- will be a subvolume
+		   |- hardlink3
+
+	In that case we cannot create `hardlink3` as hardlinks of
+	`hardlink1` and `hardlink2` because hardlink3 will be inside a new
+	subvolume.
+
 --shrink
         Shrink the filesystem to its minimal size, only works with *--rootdir* option.
 

--- a/mkfs/rootdir.c
+++ b/mkfs/rootdir.c
@@ -725,7 +725,7 @@ static int ftw_add_inode(const char *full_path, const struct stat *st,
 	parent = rootdir_path_last(&current_path);
 	root = parent->root;
 
-	/* For non-directory inode, check if there is already any hard link. */
+	/* Check if there is already a hard link record for this. */
 	if (have_hard_links) {
 		struct hardlink_entry *found;
 
@@ -771,6 +771,7 @@ static int ftw_add_inode(const char *full_path, const struct stat *st,
 		error("failed to insert inode item %llu for '%s': %m", ino, full_path);
 		return ret;
 	}
+
 	ret = btrfs_add_link(g_trans, root, ino, parent->ino,
 			     full_path + ftwbuf->base,
 			     strlen(full_path) - ftwbuf->base,
@@ -782,10 +783,7 @@ static int ftw_add_inode(const char *full_path, const struct stat *st,
 		return ret;
 	}
 
-	/*
-	 * Found a possible hard link, add it into the hard link rb tree for
-	 * future detection.
-	 */
+	/* Record this new hard link. */
 	if (have_hard_links) {
 		ret = add_hard_link(root, ino, st);
 		if (ret < 0) {

--- a/tests/mkfs-tests/036-rootdir-subvol/test.sh
+++ b/tests/mkfs-tests/036-rootdir-subvol/test.sh
@@ -11,23 +11,75 @@ prepare_test_dev
 
 tmp=$(_mktemp_dir mkfs-rootdir)
 
-run_check touch "$tmp/foo"
-run_check mkdir "$tmp/dir"
-run_check mkdir "$tmp/dir/subvol"
-run_check touch "$tmp/dir/subvol/bar"
+basic()
+{
+	run_check touch "$tmp/foo"
+	run_check mkdir "$tmp/dir"
+	run_check mkdir "$tmp/dir/subvol"
+	run_check touch "$tmp/dir/subvol/bar"
 
-run_check_mkfs_test_dev --rootdir "$tmp" --subvol dir/subvol
-run_check $SUDO_HELPER "$TOP/btrfs" check "$TEST_DEV"
+	run_check_mkfs_test_dev --rootdir "$tmp" --subvol dir/subvol
+	run_check $SUDO_HELPER "$TOP/btrfs" check "$TEST_DEV"
 
-run_check_mount_test_dev
-run_check_stdout $SUDO_HELPER "$TOP/btrfs" subvolume list "$TEST_MNT" | \
+	run_check_mount_test_dev
+	run_check_stdout $SUDO_HELPER "$TOP/btrfs" subvolume list "$TEST_MNT" | \
 	cut -d\  -f9 > "$tmp/output"
-run_check_umount_test_dev
+	run_check_umount_test_dev
 
-result=$(cat "$tmp/output")
+	result=$(cat "$tmp/output")
 
-if [ "$result" != "dir/subvol" ]; then
-	_fail "dir/subvol not in subvolume list"
-fi
+	if [ "$result" != "dir/subvol" ]; then
+		_fail "dir/subvol not in subvolume list"
+	fi
+	rm -rf -- "$tmp/foo" "$tmp/dir"
+}
 
+basic_hardlinks()
+{
+	run_check touch "$tmp/hl1"
+	run_check ln "$tmp/hl1" "$tmp/hl2"
+	run_check mkdir "$tmp/dir"
+	run_check ln "$tmp/hl1" "$tmp/dir/hl3"
+
+	run_check_mkfs_test_dev --rootdir "$tmp"
+	run_check $SUDO_HELPER "$TOP/btrfs" check "$TEST_DEV"
+
+	run_check_mount_test_dev
+	nr_hardlink=$(run_check_stdout $SUDO_HELPER stat -c "%h" "$TEST_MNT/hl1")
+
+	if [ "$nr_hardlink" -ne 3 ]; then
+		_fail "hard link number incorrect, has ${nr_hardlink} expect 3"
+	fi
+	run_check_umount_test_dev
+	rm -rf -- "$tmp/hl1" "$tmp/hl2" "$tmp/dir"
+}
+
+split_by_subvolume_hardlinks()
+{
+	run_check touch "$tmp/hl1"
+	run_check ln "$tmp/hl1" "$tmp/hl2"
+	run_check mkdir "$tmp/subv"
+	run_check ln "$tmp/hl1" "$tmp/subv/hl3"
+
+	run_check_mkfs_test_dev --rootdir "$tmp" --subvol subv
+	run_check $SUDO_HELPER "$TOP/btrfs" check "$TEST_DEV"
+
+	run_check_mount_test_dev
+	nr_hardlink=$(run_check_stdout $SUDO_HELPER stat -c "%h" "$TEST_MNT/hl1")
+
+	if [ "$nr_hardlink" -ne 2 ]; then
+		_fail "hard link number incorrect for hl1, has ${nr_hardlink} expect 2"
+	fi
+
+	nr_hardlink=$(run_check_stdout $SUDO_HELPER stat -c "%h" "$TEST_MNT/subv/hl3")
+	if [ "$nr_hardlink" -ne 1 ]; then
+		_fail "hard link number incorrect for subv/hl3, has ${nr_hardlink} expect 1"
+	fi
+	run_check_umount_test_dev
+	rm -rf -- "$tmp/hl1" "$tmp/hl2" "$tmp/dir"
+}
+
+basic
+basic_hardlinks
+split_by_subvolume_hardlinks
 rm -rf -- "$tmp"


### PR DESCRIPTION
With the recently reworked --rootdir support, although it solves several
hard link related problems, it splits the hard links into new inodes.

And on each split, it shows a warning on each file with hardlinks.

Although the split behavior doesn't cause any data corruption, it can
still be pretty noisy for rootfs creation, as there are a lot of distros
storing timezone files as hardlinks.

This patchset adds back the hard link detection and creation, with
enhanced handling to co-operate with --subvol option.

The details can be found in the first patch, with the new corner case
introduced by --subvol option.

The second patch enhances the existing --rootdir and --subvol test case
with extra corner cases like hard links, and hard links split by
subvolume boundary.