### PR TITLE
btrfs-progs: mkfs: add new option --ro-subvol

### DIFF
--- a/Documentation/mkfs.btrfs.rst
+++ b/Documentation/mkfs.btrfs.rst
@@ -163,6 +163,7 @@ OPTIONS
         *flags* is an optional comma-separated list of modifiers. Valid choices are:
 
         * *default*: create as default subvolume (this can only be specified once)
+        * *ro*: create as readonly subvolume
 
 --shrink
         Shrink the filesystem to its minimal size, only works with *--rootdir* option.

--- a/Documentation/mkfs.btrfs.rst
+++ b/Documentation/mkfs.btrfs.rst
@@ -155,10 +155,14 @@ OPTIONS
                 contain the files from *rootdir*. Since version 4.14.1 the filesystem size is
                 not minimized. Please see option *--shrink* if you need that functionality.
 
--u|--subvol <subdir>
+-u|--subvol <subdir>:<flags>
         Specify that *subdir* is to be created as a subvolume rather than a regular
         directory.  The option *--rootdir* must also be specified, and *subdir* must be an
         existing subdirectory within it.  This option can be specified multiple times.
+
+        *flags* is an optional comma-separated list of modifiers. Valid choices are:
+
+        * *default*: create as default subvolume (this can only be specified once)
 
 --shrink
         Shrink the filesystem to its minimal size, only works with *--rootdir* option.

--- a/common/root-tree-utils.c
+++ b/common/root-tree-utils.c
@@ -66,7 +66,8 @@ error:
  * The created tree root would have its root_ref as 1.
  * Thus for subvolumes caller needs to properly add ROOT_BACKREF items.
  */
-int btrfs_make_subvolume(struct btrfs_trans_handle *trans, u64 objectid)
+int btrfs_make_subvolume(struct btrfs_trans_handle *trans, u64 objectid,
+			 bool readonly)
 {
 	struct btrfs_fs_info *fs_info = trans->fs_info;
 	struct btrfs_root *root;
@@ -98,6 +99,13 @@ int btrfs_make_subvolume(struct btrfs_trans_handle *trans, u64 objectid)
 	ret = btrfs_make_root_dir(trans, root, BTRFS_FIRST_FREE_OBJECTID);
 	if (ret < 0)
 		goto error;
+
+	btrfs_set_stack_inode_flags(&root->root_item.inode,
+				    BTRFS_INODE_ROOT_ITEM_INIT);
+
+	if (readonly)
+		btrfs_set_root_flags(&root->root_item, BTRFS_ROOT_SUBVOL_RDONLY);
+
 	ret = btrfs_update_root(trans, fs_info->tree_root, &root->root_key,
 				&root->root_item);
 	if (ret < 0)

--- a/common/root-tree-utils.h
+++ b/common/root-tree-utils.h
@@ -21,7 +21,8 @@
 
 int btrfs_make_root_dir(struct btrfs_trans_handle *trans,
 			struct btrfs_root *root, u64 objectid);
-int btrfs_make_subvolume(struct btrfs_trans_handle *trans, u64 objectid);
+int btrfs_make_subvolume(struct btrfs_trans_handle *trans, u64 objectid,
+			 bool readonly);
 int btrfs_link_subvolume(struct btrfs_trans_handle *trans,
 			 struct btrfs_root *parent_root,
 			 u64 parent_dir, const char *name,

--- a/convert/main.c
+++ b/convert/main.c
@@ -1022,13 +1022,14 @@ static int init_btrfs(struct btrfs_mkfs_config *cfg, struct btrfs_root *root,
 			     BTRFS_FIRST_FREE_OBJECTID);
 
 	/* subvol for fs image file */
-	ret = btrfs_make_subvolume(trans, CONV_IMAGE_SUBVOL_OBJECTID);
+	ret = btrfs_make_subvolume(trans, CONV_IMAGE_SUBVOL_OBJECTID, false);
 	if (ret < 0) {
 		error("failed to create subvolume image root: %d", ret);
 		goto err;
 	}
 	/* subvol for data relocation tree */
-	ret = btrfs_make_subvolume(trans, BTRFS_DATA_RELOC_TREE_OBJECTID);
+	ret = btrfs_make_subvolume(trans, BTRFS_DATA_RELOC_TREE_OBJECTID,
+				   false);
 	if (ret < 0) {
 		error("failed to create DATA_RELOC root: %d", ret);
 		goto err;

--- a/mkfs/main.c
+++ b/mkfs/main.c
@@ -440,7 +440,7 @@ static const char * const mkfs_usage[] = {
 	"Creation:",
 	OPTLINE("-b|--byte-count SIZE", "set size of each device to SIZE (filesystem size is sum of all device sizes)"),
 	OPTLINE("-r|--rootdir DIR", "copy files from DIR to the image root directory"),
-	OPTLINE("-u|--subvol SUBDIR", "create SUBDIR as subvolume rather than normal directory, can be specified multiple times"),
+	OPTLINE("-u|--subvol SUBDIR:FLAGS", "create SUBDIR as subvolume rather than normal directory, can be specified multiple times"),
 	OPTLINE("--shrink", "(with --rootdir) shrink the filled filesystem to minimal size"),
 	OPTLINE("-K|--nodiscard", "do not perform whole device TRIM"),
 	OPTLINE("-f|--force", "force overwrite of existing filesystem"),
@@ -1015,6 +1015,46 @@ static void *prepare_one_device(void *ctx)
 	return NULL;
 }
 
+static int parse_subvol_flags(struct rootdir_subvol *subvol, const char *flags)
+{
+	char *buf, *orig_buf;
+	int ret;
+
+	buf = orig_buf = strdup(flags);
+
+	if (!buf) {
+		error_msg(ERROR_MSG_MEMORY, NULL);
+		ret = -ENOMEM;
+		goto out;
+	}
+
+	while (true) {
+		char *comma = strstr(buf, ",");
+
+		if (comma)
+			*comma = 0;
+
+		if (!strcmp(buf, "default")) {
+			subvol->is_default = true;
+		} else if (buf[0] != 0) {
+			error("unrecognized subvol flag \"%s\"", buf);
+			ret = 1;
+			goto out;
+		}
+
+		if (comma)
+			buf = comma + 1;
+		else
+			break;
+	}
+
+	ret = 0;
+
+out:
+	free(orig_buf);
+	return ret;
+}
+
 int BOX_MAIN(mkfs)(int argc, char **argv)
 {
 	char *file;
@@ -1058,6 +1098,7 @@ int BOX_MAIN(mkfs)(int argc, char **argv)
 	char *source_dir = NULL;
 	size_t source_dir_len = 0;
 	struct rootdir_subvol *rds;
+	bool has_default_subvol = false;
 	LIST_HEAD(subvols);
 
 	cpu_detect_flags();
@@ -1215,16 +1256,49 @@ int BOX_MAIN(mkfs)(int argc, char **argv)
 				break;
 			case 'u': {
 				struct rootdir_subvol *subvol;
+				char *colon;
 
-				subvol = malloc(sizeof(struct rootdir_subvol));
+				subvol = calloc(1, sizeof(struct rootdir_subvol));
 				if (!subvol) {
 					error_msg(ERROR_MSG_MEMORY, NULL);
 					ret = 1;
 					goto error;
 				}
 
-				subvol->dir = strdup(optarg);
-				subvol->full_path = NULL;
+				colon = strstr(optarg, ":");
+
+				if (colon) {
+					/* Make sure we choose the last colon in
+					 * optarg, in case the subvol name
+					 * itself contains a colon.  */
+					do {
+						char *colon2;
+
+						colon2 = strstr(colon + 1, ":");
+
+						if (colon2)
+							colon = colon2;
+						else
+							break;
+					} while (true);
+
+					subvol->dir = strndup(optarg, colon - optarg);
+					if (parse_subvol_flags(subvol, colon + 1)) {
+						ret = 1;
+						goto error;
+					}
+				} else {
+					subvol->dir = strdup(optarg);
+				}
+
+				if (subvol->is_default) {
+					if (has_default_subvol) {
+						error("subvol default flag can only be specified once");
+						ret = 1;
+						goto error;
+					}
+					has_default_subvol = true;
+				}
 
 				list_add_tail(&subvol->list, &subvols);
 				break;

--- a/mkfs/main.c
+++ b/mkfs/main.c
@@ -1036,6 +1036,8 @@ static int parse_subvol_flags(struct rootdir_subvol *subvol, const char *flags)
 
 		if (!strcmp(buf, "default")) {
 			subvol->is_default = true;
+		} else if (!strcmp(buf, "ro")) {
+			subvol->readonly = true;
 		} else if (buf[0] != 0) {
 			error("unrecognized subvol flag \"%s\"", buf);
 			ret = 1;
@@ -1987,7 +1989,8 @@ raid_groups:
 		goto out;
 	}
 
-	ret = btrfs_make_subvolume(trans, BTRFS_DATA_RELOC_TREE_OBJECTID);
+	ret = btrfs_make_subvolume(trans, BTRFS_DATA_RELOC_TREE_OBJECTID,
+				   false);
 	if (ret) {
 		error("unable to create data reloc tree: %d", ret);
 		goto out;

--- a/mkfs/rootdir.c
+++ b/mkfs/rootdir.c
@@ -430,7 +430,7 @@ static int ftw_add_subvol(const char *full_path, const struct stat *st,
 
 	subvol_id = next_subvol_id++;
 
-	ret = btrfs_make_subvolume(g_trans, subvol_id);
+	ret = btrfs_make_subvolume(g_trans, subvol_id, subvol->readonly);
 	if (ret < 0) {
 		errno = -ret;
 		error("failed to create subvolume: %m");

--- a/mkfs/rootdir.h
+++ b/mkfs/rootdir.h
@@ -33,6 +33,7 @@ struct rootdir_subvol {
 	char *dir;
 	char *full_path;
 	bool is_default;
+	bool readonly;
 };
 
 int btrfs_mkfs_fill_dir(struct btrfs_trans_handle *trans, const char *source_dir,

--- a/mkfs/rootdir.h
+++ b/mkfs/rootdir.h
@@ -32,6 +32,7 @@ struct rootdir_subvol {
 	struct list_head list;
 	char *dir;
 	char *full_path;
+	bool is_default;
 };
 
 int btrfs_mkfs_fill_dir(struct btrfs_trans_handle *trans, const char *source_dir,


### PR DESCRIPTION
Adds an --ro-subvol option to mkfs.btrfs, which allows the creation of read-only subvolumes when using --rootdir.