### PR TITLE
btrfs-progs: convert: fix the invalid regular extents for symbol links

### DIFF
--- a/check/main.c
+++ b/check/main.c
@@ -1745,6 +1745,13 @@ static int process_file_extent(struct btrfs_root *root,
 			rec->errors |= I_ERR_BAD_FILE_EXTENT;
 		if (disk_bytenr > 0)
 			rec->found_size += num_bytes;
+		/*
+		 * Symbolic links should only have inlined extents.
+		 * A regular extent means it's already too large to
+		 * be inlined.
+		 */
+		if (S_ISLNK(rec->imode))
+			rec->errors |= I_ERR_FILE_EXTENT_TOO_LARGE;
 	} else {
 		rec->errors |= I_ERR_BAD_FILE_EXTENT;
 	}

--- a/convert/source-reiserfs.c
+++ b/convert/source-reiserfs.c
@@ -537,9 +537,15 @@ static int reiserfs_copy_symlink(struct btrfs_trans_handle *trans,
 	symlink = tp_item_body(&path);
 	len = get_ih_item_len(tp_item_head(&path));
 
+	if (len > btrfs_symlink_max_size(trans->fs_info)) {
+		error("symlink too large, has %u max %u",
+		      len, btrfs_symlink_max_size(trans->fs_info));
+		ret = -ENAMETOOLONG;
+		goto fail;
+	}
 	ret = btrfs_insert_inline_extent(trans, root, objectid, 0,
-					 symlink, len + 1);
-	btrfs_set_stack_inode_nbytes(btrfs_inode, len + 1);
+					 symlink, len);
+	btrfs_set_stack_inode_nbytes(btrfs_inode, len);
 fail:
 	pathrelse(&path);
 	return ret;

--- a/kernel-shared/file-item.c
+++ b/kernel-shared/file-item.c
@@ -26,6 +26,7 @@
 #include "kernel-shared/extent_io.h"
 #include "kernel-shared/uapi/btrfs.h"
 #include "common/internal.h"
+#include "common/messages.h"
 
 #define MAX_CSUM_ITEMS(r, size) ((((BTRFS_LEAF_DATA_SIZE(r->fs_info) - \
 			       sizeof(struct btrfs_item) * 2) / \
@@ -88,6 +89,7 @@ int btrfs_insert_inline_extent(struct btrfs_trans_handle *trans,
 			       struct btrfs_root *root, u64 objectid,
 			       u64 offset, const char *buffer, size_t size)
 {
+	struct btrfs_fs_info *fs_info = trans->fs_info;
 	struct btrfs_key key;
 	struct btrfs_path *path;
 	struct extent_buffer *leaf;
@@ -96,6 +98,10 @@ int btrfs_insert_inline_extent(struct btrfs_trans_handle *trans,
 	u32 datasize;
 	int err = 0;
 	int ret;
+
+	if (size > max(btrfs_symlink_max_size(fs_info),
+		       btrfs_data_inline_max_size(fs_info)))
+		return -EUCLEAN;
 
 	path = btrfs_alloc_path();
 	if (!path)

--- a/kernel-shared/file-item.h
+++ b/kernel-shared/file-item.h
@@ -92,5 +92,23 @@ int btrfs_csum_file_block(struct btrfs_trans_handle *trans, u64 logical,
 int btrfs_insert_inline_extent(struct btrfs_trans_handle *trans,
 			       struct btrfs_root *root, u64 objectid,
 			       u64 offset, const char *buffer, size_t size);
+/*
+ * For symlink we allow up to PATH_MAX - 1 (PATH_MAX includes the terminating NUL,
+ * but fs doesn't store that terminating NUL).
+ *
+ * But for inlined data extents, the up limit is sectorsize - 1 (inclusive), or a
+ * regular extent should be created instead.
+ */
+static inline u32 btrfs_symlink_max_size(struct btrfs_fs_info *fs_info)
+{
+	return min_t(u32, BTRFS_MAX_INLINE_DATA_SIZE(fs_info),
+		     PATH_MAX - 1);
+}
+
+static inline u32 btrfs_data_inline_max_size(struct btrfs_fs_info *fs_info)
+{
+	return min_t(u32, BTRFS_MAX_INLINE_DATA_SIZE(fs_info),
+		     fs_info->sectorsize - 1);
+}
 
 #endif

--- a/tests/convert-tests/027-large-symbol-link/test.sh
+++ b/tests/convert-tests/027-large-symbol-link/test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Make sure btrfs-convert can handle a symbol link which is 4095 bytes large
+
+source "$TEST_TOP/common" || exit
+source "$TEST_TOP/common.convert" || exit
+
+setup_root_helper
+prepare_test_dev 1G
+check_global_prereq mkfs.ext4
+
+# This is at the symbolic link size limit (PATH_MAX includes the terminating NUL).
+link_target=$(printf "%0.sb" {1..4095})
+
+convert_test_prep_fs ext4 mke2fs -t ext4 -b 4096
+run_check $SUDO_HELPER ln -s "$link_target" "$TEST_MNT/symbol_link"
+run_check_umount_test_dev
+
+# For unpatched btrfs-convert, it will always append one byte to the
+# link target, causing above 4095 target to be 4096, exactly one sector,
+# resulting a regular file extent.
+convert_test_do_convert
+
+run_check_mount_test_dev
+# If the unpatched btrfs-convert created a regular extent, and the kernel is
+# newer enough, such readlink will be rejected by kernel.
+run_check $SUDO_HELPER readlink "$TEST_MNT/symbol_link"
+run_check_umount_test_dev


### PR DESCRIPTION
Test case btrfs/012 fails randomly after the rework to use fsstress to
populate the fs.

It turns out that, if fsstress creates a symbol link whose target is
4095 bytes (at the max size limit), btrfs-convert will create a regular
extent instead of the expected inline one.

This regular extent for symbol link inodes will be rejected by kernel,
resulting test case failure.

The reason that btrfs-convert created such regular extent is,
btrfs-convert accidentally added one byte for the terminating NUL,
enlarge the should-be inlined file extent to be a regular one.

The first patch will fix the bug.
Then two patches to enahnce btrfs-check to detect the error (regular and
lowmem mode)
Eventually a dedicated test case for btrfs-convert, so in the future we
won't cause the problem again.