### PR TITLE
btrfs-progs: open the devices exclusively for writes

### DIFF
--- a/cmds/rescue.c
+++ b/cmds/rescue.c
@@ -203,7 +203,7 @@ static int cmd_rescue_zero_log(const struct cmd_struct *cmd,
 	}
 
 	root = open_ctree(devname, 0, OPEN_CTREE_WRITES | OPEN_CTREE_PARTIAL |
-			  OPEN_CTREE_NO_BLOCK_GROUPS);
+			  OPEN_CTREE_NO_BLOCK_GROUPS | OPEN_CTREE_EXCLUSIVE);
 	if (!root) {
 		error("could not open ctree");
 		return 1;
@@ -258,7 +258,7 @@ static int cmd_rescue_fix_device_size(const struct cmd_struct *cmd,
 	}
 
 	oca.filename = devname;
-	oca.flags = OPEN_CTREE_WRITES | OPEN_CTREE_PARTIAL;
+	oca.flags = OPEN_CTREE_WRITES | OPEN_CTREE_PARTIAL | OPEN_CTREE_EXCLUSIVE;
 	fs_info = open_ctree_fs_info(&oca);
 	if (!fs_info) {
 		error("could not open btrfs");
@@ -437,7 +437,7 @@ static int cmd_rescue_clear_ino_cache(const struct cmd_struct *cmd,
 		goto out;
 	}
 	oca.filename = devname;
-	oca.flags = OPEN_CTREE_WRITES;
+	oca.flags = OPEN_CTREE_WRITES | OPEN_CTREE_EXCLUSIVE;
 	fs_info = open_ctree_fs_info(&oca);
 	if (!fs_info) {
 		error("could not open btrfs");

--- a/common/filesystem-utils.c
+++ b/common/filesystem-utils.c
@@ -94,7 +94,8 @@ static int set_label_unmounted(const char *dev, const char *label)
 	/* Open the super_block at the default location
 	 * and as read-write.
 	 */
-	root = open_ctree(dev, 0, OPEN_CTREE_WRITES);
+	root = open_ctree(dev, 0, OPEN_CTREE_WRITES |
+				  OPEN_CTREE_EXCLUSIVE);
 	if (!root) /* errors are printed by open_ctree() */
 		return -1;
 

--- a/convert/main.c
+++ b/convert/main.c
@@ -1374,7 +1374,8 @@ static int do_convert(const char *devname, u32 convert_flags, u32 nodesize,
 	btrfs_sb_committed = true;
 
 	root = open_ctree_fd(fd, devname, 0,
-			     OPEN_CTREE_WRITES | OPEN_CTREE_TEMPORARY_SUPER);
+			     OPEN_CTREE_WRITES | OPEN_CTREE_TEMPORARY_SUPER |
+			     OPEN_CTREE_EXCLUSIVE);
 	if (!root) {
 		error("unable to open ctree for finalization");
 		goto fail;

--- a/image/image-restore.c
+++ b/image/image-restore.c
@@ -1790,7 +1790,8 @@ int restore_metadump(const char *input, FILE *out, int old_restore,
 
 		oca.filename = target;
 		oca.flags = OPEN_CTREE_WRITES | OPEN_CTREE_RESTORE |
-			    OPEN_CTREE_PARTIAL | OPEN_CTREE_SKIP_LEAF_ITEM_CHECKS;
+			    OPEN_CTREE_PARTIAL | OPEN_CTREE_SKIP_LEAF_ITEM_CHECKS |
+			    OPEN_CTREE_EXCLUSIVE;
 		info = open_ctree_fs_info(&oca);
 		if (!info) {
 			error("open ctree failed");
@@ -1855,6 +1856,7 @@ int restore_metadump(const char *input, FILE *out, int old_restore,
 		root = open_ctree_fd(fileno(out), target, 0,
 					  OPEN_CTREE_PARTIAL |
 					  OPEN_CTREE_WRITES |
+					  OPEN_CTREE_EXCLUSIVE |
 					  OPEN_CTREE_NO_DEVICES |
 					  OPEN_CTREE_ALLOW_TRANSID_MISMATCH |
 					  OPEN_CTREE_SKIP_LEAF_ITEM_CHECKS);

--- a/mkfs/main.c
+++ b/mkfs/main.c
@@ -1846,7 +1846,8 @@ int BOX_MAIN(mkfs)(int argc, char **argv)
 	}
 
 	oca.filename = file;
-	oca.flags = OPEN_CTREE_WRITES | OPEN_CTREE_TEMPORARY_SUPER;
+	oca.flags = OPEN_CTREE_WRITES | OPEN_CTREE_TEMPORARY_SUPER |
+		    OPEN_CTREE_EXCLUSIVE;
 	fs_info = open_ctree_fs_info(&oca);
 	if (!fs_info) {
 		error("open ctree failed");

--- a/tune/main.c
+++ b/tune/main.c
@@ -185,7 +185,7 @@ int BOX_MAIN(btrfstune)(int argc, char *argv[])
 {
 	struct btrfs_root *root;
 	struct btrfs_fs_info *fs_info;
-	unsigned ctree_flags = OPEN_CTREE_WRITES;
+	unsigned ctree_flags = OPEN_CTREE_WRITES | OPEN_CTREE_EXCLUSIVE;
 	int seeding_flag = 0;
 	u64 seeding_value = 0;
 	int random_fsid = 0;


### PR DESCRIPTION
There is an internal report that, during btrfs-convert to block-group tree, by accident some systemd events triggered the mount of the target fs.

This leads to double mount (one by kernel and one by the btrfs-progs), which seems to cause quite some problems.

To avoid such accident, exclusively opens all devices if btrfs-progs is doing write operations.

Reported-by: pandada8 <pandada8@gmail.com>