### PR TITLE
btrfs-progs: fix a false failure for inode cache cleanup

### DIFF
--- a/cmds/rescue.c
+++ b/cmds/rescue.c
@@ -449,7 +449,7 @@ static int cmd_rescue_clear_ino_cache(const struct cmd_struct *cmd,
 		errno = -ret;
 		error("failed to clear ino cache: %m");
 	} else {
-		pr_verbose(LOG_DEFAULT, "Successfully cleared ino cache");
+		pr_verbose(LOG_DEFAULT, "Successfully cleared ino cache\n");
 	}
 	close_ctree(fs_info->tree_root);
 out:


### PR DESCRIPTION
[BUG]
There is one report about `btrfs rescue clear-ino-cache` failed with tree block level mismatch:

 # btrfs rescue clear-ino-cache /dev/mapper/rootext
 Successfully cleaned up ino cache for root id: 5
 Successfully cleaned up ino cache for root id: 257
 Successfully cleaned up ino cache for root id: 258
 corrupt node: root=7 block=647369064448 slot=0, invalid level for leaf, have 1 expect 0
 node 647369064448 level 1 items 252 free space 241 generation 6065173 owner CSUM_TREE
 node 647369064448 flags 0x1(WRITTEN) backref revision 1
 fs uuid e6614f01-6f56-4776-8b0a-c260089c35e7
 chunk uuid f665f535-4cfd-49e0-8be9-7f94bf59b75d
     key (EXTENT_CSUM EXTENT_CSUM 3714473984) block 677126111232 gen 6065002
     [...]
     key (EXTENT_CSUM EXTENT_CSUM 6192357376) block 646396493824 gen 6065032
 ERROR: failed to clear ino cache: Input/output error

[CAUSE]
During `btrfs rescue clear-ino-cache`, btrfs-progs will iterate through all the subvolumes, and clear the inode cache inode from each subvolume.

The problem is in how we iterate the subvolumes.

We hold a path of tree root, and go modifiy the fs for each found subvolume, then call btrfs_next_item().

This is not safe, because the path to tree root is not longer reliable if we modified the fs.

So the btrfs_next_item() call will fail because the fs is modified halfway, resulting the above problem.

[FIX]
Instead of holding a path to a subvolume root item, and modify the fs halfway, here introduce a helper, find_next_root(), to locate the root item whose objectid >= our target rootid, and return the found item key.

The path to root tree is only hold then released inside find_next_root().

By this, we won't hold any unrelated path while modifying the filesystem.

And since we're here, also adding back the missing new line when all ino cache is cleared.

Reported-by: Archange <archange@archlinux.org>
Link: https://lore.kernel.org/linux-btrfs/4803f696-2dc5-4987-a353-fce1272e93e7@archlinux.org/