### PR TITLE
btrfs-progs: install btrfs-ioctl man page

### DIFF
--- a/Documentation/Makefile.in
+++ b/Documentation/Makefile.in
@@ -23,6 +23,7 @@ endif
 endif
 
 mandir ?= $(prefix)/share/man
+man2dir = $(mandir)/man2
 man3dir = $(mandir)/man3
 man5dir = $(mandir)/man5
 man8dir = $(mandir)/man8
@@ -44,8 +45,10 @@ help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 install: man
+	$(INSTALL) -d -m 755 $(DESTDIR)$(man2dir)
 	$(INSTALL) -d -m 755 $(DESTDIR)$(man5dir)
 	$(INSTALL) -d -m 755 $(DESTDIR)$(man8dir)
+	$(INSTALL) -m 644 $(BUILDDIR)/man/*.2 $(DESTDIR)$(man2dir)
 	$(INSTALL) -m 644 $(BUILDDIR)/man/*.5 $(DESTDIR)$(man5dir)
 	$(INSTALL) -m 644 $(BUILDDIR)/man/*.8 $(DESTDIR)$(man8dir)
 	$(INSTALL) -m 644 btrfsck.8 $(DESTDIR)$(man8dir)

--- a/Documentation/btrfs-man5.rst
+++ b/Documentation/btrfs-man5.rst
@@ -455,6 +455,7 @@ SEE ALSO
 :manref:`chattr(1)`,
 :manref:`fstrim(8)`,
 :manref:`ioctl(2)`,
+:doc:`btrfs-ioctl`,
 :doc:`mkfs.btrfs`,
 :manref:`mount(8)`,
 :manref:`swapon(8)`

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -66,6 +66,7 @@ man_pages = [
     ('btrfs-qgroup', 'btrfs-qgroup', 'control the quota group of a btrfs filesystem', '', 8),
     ('btrfs-property', 'btrfs-property', 'get/set/list properties for given filesystem object', '', 8),
     ('btrfs-inspect-internal', 'btrfs-inspect-internal', 'query various internal information', '', 8),
+    ('btrfs-ioctl', 'btrfs-ioctl', 'documentation about btrfs ioctls', '', 2),
     ('btrfs-image', 'btrfs-image', 'create/restore an image of the filesystem', '', 8),
     ('btrfs-find-root', 'btrfs-find-root', 'filter to find btrfs root', '', 8),
     ('btrfs-filesystem', 'btrfs-filesystem', 'command group that primarily does work on the whole filesystems', '', 8),

--- a/Documentation/man-index.rst
+++ b/Documentation/man-index.rst
@@ -16,6 +16,7 @@ Manual pages
    btrfs-find-root
    btrfs-image
    btrfs-inspect-internal
+   btrfs-ioctl
    btrfs-map-logical
    btrfs-property
    btrfs-qgroup


### PR DESCRIPTION
btrfs-ioctl.rst was laid out like it should be a man page, including having a section number, but it wasn't getting installed as such.