### PR TITLE
btrfs-progs: libbtrfsutil: use package_data member for header files

### DIFF
--- a/libbtrfsutil/python/.gitignore
+++ b/libbtrfsutil/python/.gitignore
@@ -5,4 +5,3 @@ __pycache__
 /build
 /constants.c
 /dist
-/pypi-README.md

--- a/libbtrfsutil/python/.gitignore
+++ b/libbtrfsutil/python/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 /build
 /constants.c
 /dist
+/pypi-README.md

--- a/libbtrfsutil/python/setup.py
+++ b/libbtrfsutil/python/setup.py
@@ -68,26 +68,8 @@ void add_module_constants(PyObject *m)
 """)
 
 
-def read_readme():
-    # FIXME: hackish, needs to be run twice to work
-    if not os.path.exists('pypi-README.md'):
-        copy_readme()
-        raise Exception("Copied ../README.md to pypi-README.md, run again")
-    with open('pypi-README.md', 'r') as f:
-        desc = f.read()
-    return desc
-
-
-def copy_readme():
-    with open('../README.md', 'r') as f:
-        desc = f.read()
-    with open('pypi-README.md', 'w') as f:
-        f.write(desc)
-
-
 class my_build_ext(build_ext):
     def run(self):
-        open(os.path.join(os.path.dirname(__file__), "pypi-README.md"), 'r')
         # Running dist outside of git
         if not os.path.exists('../btrfsutil.h'):
             # But no generated constants.c found
@@ -99,19 +81,6 @@ class my_build_ext(build_ext):
             except Exception as e:
                 try:
                     os.remove('constants.c')
-                except OSError:
-                    pass
-                raise e
-        if not os.path.exists('../README.md'):
-            # But no generated constants.c found
-            if not os.path.exists('pypi-README.md'):
-                raise Exception("The temporary description file pypi-README.md not found, please fix manually")
-        elif out_of_date(['../README.md'], 'pypi-README.md'):
-            try:
-                copy_readme()
-            except Exception as e:
-                try:
-                    os.remove('pypi-README.md')
                 except OSError:
                     pass
                 raise e
@@ -142,7 +111,7 @@ setup(
     #version=get_version(),
     version='6.11',
     description='Library for managing Btrfs filesystems',
-    long_description=read_readme(),
+    long_description=open('../README.md').read(),
     long_description_content_type='text/markdown',
     url='https://github.com/kdave/btrfs-progs',
     license='LGPLv2+',

--- a/libbtrfsutil/python/setup.py
+++ b/libbtrfsutil/python/setup.py
@@ -68,8 +68,26 @@ void add_module_constants(PyObject *m)
 """)
 
 
+def read_readme():
+    # FIXME: hackish, needs to be run twice to work
+    if not os.path.exists('pypi-README.md'):
+        copy_readme()
+        raise Exception("Copied ../README.md to pypi-README.md, run again")
+    with open('pypi-README.md', 'r') as f:
+        desc = f.read()
+    return desc
+
+
+def copy_readme():
+    with open('../README.md', 'r') as f:
+        desc = f.read()
+    with open('pypi-README.md', 'w') as f:
+        f.write(desc)
+
+
 class my_build_ext(build_ext):
     def run(self):
+        open(os.path.join(os.path.dirname(__file__), "pypi-README.md"), 'r')
         # Running dist outside of git
         if not os.path.exists('../btrfsutil.h'):
             # But no generated constants.c found
@@ -81,6 +99,19 @@ class my_build_ext(build_ext):
             except Exception as e:
                 try:
                     os.remove('constants.c')
+                except OSError:
+                    pass
+                raise e
+        if not os.path.exists('../README.md'):
+            # But no generated constants.c found
+            if not os.path.exists('pypi-README.md'):
+                raise Exception("The temporary description file pypi-README.md not found, please fix manually")
+        elif out_of_date(['../README.md'], 'pypi-README.md'):
+            try:
+                copy_readme()
+            except Exception as e:
+                try:
+                    os.remove('pypi-README.md')
                 except OSError:
                     pass
                 raise e
@@ -111,6 +142,8 @@ setup(
     #version=get_version(),
     version='6.11',
     description='Library for managing Btrfs filesystems',
+    long_description=read_readme(),
+    long_description_content_type='text/markdown',
     url='https://github.com/kdave/btrfs-progs',
     license='LGPLv2+',
     cmdclass={'build_ext': my_build_ext},

--- a/libbtrfsutil/python/setup.py
+++ b/libbtrfsutil/python/setup.py
@@ -97,9 +97,6 @@ module = Extension(
         'qgroup.c',
         'subvolume.c',
     ],
-    headers=[
-        'btrfsutilpy.h'
-    ],
     include_dirs=['..'],
     library_dirs=['../..'],
     libraries=['btrfsutil'],
@@ -113,6 +110,7 @@ setup(
     description='Library for managing Btrfs filesystems',
     long_description=open('../README.md').read(),
     long_description_content_type='text/markdown',
+    package_data = { "btrfstuil" : [ "btrfsutilpy.h" ] },
     url='https://github.com/kdave/btrfs-progs',
     license='LGPLv2+',
     cmdclass={'build_ext': my_build_ext},


### PR DESCRIPTION
[BUG]
Currently with python3.12, the python bindding will always result the following warning:
```
    [PY]     libbtrfsutil
/usr/lib/python3.12/site-packages/setuptools/_distutils/extension.py:134: UserWarning: Unknown Extension options: 'headers'
  warnings.warn(msg)
```

[CAUSE]
In the setup.py which specifies the files to be included into the package, we use setuptools::Extension to specify the file lists and include paths.

But there is no handling of Extension::headers member, thus resulting the above warning.

[FIX]
Not an expert in python, but other packages like cffi are all using `package_data` to include the headers, so just follow them to use `package_data` member for headers.

Fixes: 87c3fb557ef2 ("libbtrfsutil: update python setup.py for distribution")