### PR TITLE
btrfs-progs: libbtrfsutil/python: fix all the warnings

### DIFF
--- a/libbtrfsutil/python/MANIFEST.in
+++ b/libbtrfsutil/python/MANIFEST.in
@@ -1,0 +1,1 @@
+include btrfsutilpy.h

--- a/libbtrfsutil/python/README.md
+++ b/libbtrfsutil/python/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/libbtrfsutil/python/setup.py
+++ b/libbtrfsutil/python/setup.py
@@ -97,9 +97,6 @@ module = Extension(
         'qgroup.c',
         'subvolume.c',
     ],
-    headers=[
-        'btrfsutilpy.h'
-    ],
     include_dirs=['..'],
     library_dirs=['../..'],
     libraries=['btrfsutil'],

--- a/libbtrfsutil/python/setup.py
+++ b/libbtrfsutil/python/setup.py
@@ -108,6 +108,8 @@ setup(
     #version=get_version(),
     version='6.11',
     description='Library for managing Btrfs filesystems',
+    long_description=open('README.md').read(),
+    long_description_content_type='text/markdown',
     url='https://github.com/kdave/btrfs-progs',
     license='LGPLv2+',
     cmdclass={'build_ext': my_build_ext},


### PR DESCRIPTION
There are the following warnings when building the python binding the
proper way (directly calling "setup.py build" is no longer recommended):
```
 $ python -m build btrfs-progs/libbtrfsutil/python
 * Creating isolated environment: venv+pip...
 * Installing packages in isolated environment:
   - setuptools >= 40.8.0
 * Getting build dependencies for sdist...
 /tmp/build-env-2u6q_udl/lib/python3.12/site-packages/setuptools/_distutils/extension.py:139: UserWarning: Unknown Extension options: 'headers'
   warnings.warn(msg)
 * Building sdist...
 /tmp/build-env-2u6q_udl/lib/python3.12/site-packages/setuptools/_distutils/extension.py:139: UserWarning: Unknown Extension options: 'headers'
   warnings.warn(msg)
 writing manifest file 'btrfsutil.egg-info/SOURCES.txt'
 warning: sdist: standard file not found: should have one of README, README.rst, README.txt, README.md
```
This patch fixes them by:

- Use MANIFEST.in to properly include the "btrfsutilpy.h"
- Remove unnecessary build options for C files
- Reuse the existing README.md by a softlink
  So that even in a virtual environment the README.md will still be
  properly copied.

TODO: Migrate the "python setup.py build" system to "python -m build"
for building and tox for tests.