### PR TITLE
btrfs-progs: print-tree: cleanup for regular bitmap based flags print

### DIFF
--- a/kernel-shared/print-tree.c
+++ b/kernel-shared/print-tree.c
@@ -1889,8 +1889,7 @@ static struct readable_flag_entry compat_ro_flags_array[] = {
 	DEF_COMPAT_RO_FLAG_ENTRY(FREE_SPACE_TREE_VALID),
 	DEF_COMPAT_RO_FLAG_ENTRY(BLOCK_GROUP_TREE),
 };
-static const int compat_ro_flags_num = sizeof(compat_ro_flags_array) /
-				       sizeof(struct readable_flag_entry);
+static const int compat_ro_flags_num = ARRAY_SIZE(compat_ro_flags_array);
 
 #define DEF_INCOMPAT_FLAG_ENTRY(bit_name)		\
 	{BTRFS_FEATURE_INCOMPAT_##bit_name, #bit_name}
@@ -1913,8 +1912,7 @@ static struct readable_flag_entry incompat_flags_array[] = {
 	DEF_INCOMPAT_FLAG_ENTRY(RAID_STRIPE_TREE),
 	DEF_INCOMPAT_FLAG_ENTRY(SIMPLE_QUOTA),
 };
-static const int incompat_flags_num = sizeof(incompat_flags_array) /
-				      sizeof(struct readable_flag_entry);
+static const int incompat_flags_num = ARRAY_SIZE(incompat_flags_array);
 
 #define DEF_HEADER_FLAG_ENTRY(bit_name)			\
 	{BTRFS_HEADER_FLAG_##bit_name, #bit_name}

--- a/kernel-shared/print-tree.c
+++ b/kernel-shared/print-tree.c
@@ -1933,12 +1933,16 @@ static struct readable_flag_entry super_flags_array[] = {
 };
 static const int super_flags_num = ARRAY_SIZE(super_flags_array);
 
-static void __print_readable_flag(u64 flag, struct readable_flag_entry *array,
-				  int array_size, u64 supported_flags)
+static void print_readable_flag(u64 flag, struct readable_flag_entry *array,
+				int array_size)
 {
 	int i;
 	int first = 1;
+	u64 supported_flags = 0;
 	struct readable_flag_entry *entry;
+
+	for (i = 0; i < array_size; i++)
+		supported_flags |= array[i].bit;
 
 	if (!flag)
 		return;
@@ -1966,33 +1970,20 @@ static void __print_readable_flag(u64 flag, struct readable_flag_entry *array,
 
 static void print_readable_compat_ro_flag(u64 flag)
 {
-	u64 print_flags = 0;
-
-	for (int i = 0; i < compat_ro_flags_num; i++)
-		print_flags |= compat_ro_flags_array[i].bit;
-	return __print_readable_flag(flag, compat_ro_flags_array,
-				     compat_ro_flags_num,
-				     print_flags);
+	return print_readable_flag(flag, compat_ro_flags_array,
+				   compat_ro_flags_num);
 }
 
 static void print_readable_incompat_flag(u64 flag)
 {
-	u64 print_flags = 0;
-
-	for (int i = 0; i < incompat_flags_num; i++)
-		print_flags |= incompat_flags_array[i].bit;
-	return __print_readable_flag(flag, incompat_flags_array,
-				     incompat_flags_num, print_flags);
+	return print_readable_flag(flag, incompat_flags_array,
+				   incompat_flags_num);
 }
 
 static void print_readable_super_flag(u64 flag)
 {
-	u64 print_flags = 0;
-
-	for (int i = 0; i < super_flags_num; i++)
-		print_flags |= super_flags_array[i].bit;
-	return __print_readable_flag(flag, super_flags_array,
-				     super_flags_num, print_flags);
+	return print_readable_flag(flag, super_flags_array,
+				   super_flags_num);
 }
 
 static void print_sys_chunk_array(struct btrfs_super_block *sb)


### PR DESCRIPTION
The first 2 are small cleanups for __print_readable_flag().

The last one introduces an sprint version, sprint_readable_flag(),
allowing the same bitmap handling of print_readable_flag() to be output
into a string buffer.

And use that sprint_readable_flag() to handle inode flags, inspired by a
recent report that Synology's out-of-tree btrfs can not be handled by
upstream kernel (unsupported inode flag).

This allows print-tree to handle the unknown flags of inode flags.

Unfortunately I didn't find any other location can benefit the
sprint_readable_flag() yet.

It's either bg flags which needs special handling for SINGLE profile, or
not bitmap in the first place (e.g. compress flags).