### PR TITLE
Fix false positives in log tree checking

### DIFF
--- a/check/main.c
+++ b/check/main.c
@@ -9807,9 +9807,14 @@ static int check_log_root(struct btrfs_root *root, struct cache_tree *root_cache
 			if (btrfs_file_extent_type(leaf, fi) != BTRFS_FILE_EXTENT_REG)
 				goto next;
 
-			addr = btrfs_file_extent_disk_bytenr(leaf, fi) +
-			       btrfs_file_extent_offset(leaf, fi);
-			length = btrfs_file_extent_num_bytes(leaf, fi);
+			if (btrfs_file_extent_compression(leaf, fi)) {
+				addr = btrfs_file_extent_disk_bytenr(leaf, fi);
+				length = btrfs_file_extent_disk_num_bytes(leaf, fi);
+			} else {
+				addr = btrfs_file_extent_disk_bytenr(leaf, fi) +
+				       btrfs_file_extent_offset(leaf, fi);
+				length = btrfs_file_extent_num_bytes(leaf, fi);
+			}
 
 			ret = check_log_csum(root, addr, length);
 			if (ret < 0) {

--- a/check/main.c
+++ b/check/main.c
@@ -9681,7 +9681,7 @@ static int zero_log_tree(struct btrfs_root *root)
 	return ret;
 }
 
-static int check_log_csum(struct btrfs_root *root, u64 addr, u64 length)
+static int check_range_csummed(struct btrfs_root *root, u64 addr, u64 length)
 {
 	struct btrfs_path path = { 0 };
 	struct btrfs_key key = {
@@ -9816,10 +9816,19 @@ static int check_log_root(struct btrfs_root *root, struct cache_tree *root_cache
 				length = btrfs_file_extent_num_bytes(leaf, fi);
 			}
 
-			ret = check_log_csum(root, addr, length);
+			ret = check_range_csummed(root, addr, length);
 			if (ret < 0) {
 				err = 1;
 				break;
+			}
+
+			if (ret) {
+				ret = check_range_csummed(btrfs_csum_root(gfs_info, 0),
+							  addr, length);
+				if (ret < 0) {
+					err = 1;
+					break;
+				}
 			}
 
 			if (ret) {

--- a/check/main.c
+++ b/check/main.c
@@ -9694,6 +9694,10 @@ static int check_log_csum(struct btrfs_root *root, u64 addr, u64 length)
 	u64 data_len;
 	int ret;
 
+	/* Explicit holes don't get csummed */
+	if (addr == 0)
+		return 0;
+
 	ret = btrfs_search_slot(NULL, root, &key, &path, 0, 0);
 	if (ret < 0)
 		return ret;


### PR DESCRIPTION
Filipe reported that btrfs/056 was failing due to some false positives reported by the new log-checking code in `btrfs check`.