### PR TITLE
btrfs-progs: fix the typo inside kernel-by-version.rst

### DIFF
--- a/Documentation/Kernel-by-version.rst
+++ b/Documentation/Kernel-by-version.rst
@@ -621,7 +621,7 @@ Performance improvements:
 Notable fixes or changes:
 
 - add back mount option *norecovery*, deprecated long time ago and removed in
-  6.8 but stil in use
+  6.8 but still in use
 
 - fix potential infinite loop when doing block group reclaim
 


### PR DESCRIPTION
This "stil" -> "still" typo is causing the latest CI spellchecks to fail.

Fix that so we can get a good CI run.