### PR TITLE
btrfs-progs: doc: add a note on qgroup limit with inconsitent flag

### DIFF
--- a/Documentation/btrfs-qgroup.rst
+++ b/Documentation/btrfs-qgroup.rst
@@ -31,6 +31,11 @@ ownership. For example a fresh snapshot shares almost all the blocks with the
 original subvolume, new writes to either subvolume will raise towards the
 exclusive limit.
 
+.. note::
+   Qgroup limit only works when qgroup is in a consistent status.
+   If by some workload, qgroup is mark inconsistent, the limit will no longer
+   work until the inconsistent flag is cleared by a rescan.
+
 The qgroup identifiers conform to *level/id* where level 0 is reserved to the
 qgroups associated with subvolumes. Such qgroups are created automatically.
 


### PR DESCRIPTION
Just like all qgroup functions, if qgroup is marked inconsistent, limit will not work as expected.
In fact with recent kernels, limit and qgroup number updating will be fully skipped if qgroup is already inconsistent.

Add one extra note on `btrfs qgroup limit` subcommand for it.

Reported-by: Vojtech Lacina <vlacina@suse.com>
Link: https://bugzilla.suse.com/show_bug.cgi?id=1235765