### PR TITLE
btrfs-progs: scrub: add the new -t option to set the limit at runtime

### DIFF
--- a/Documentation/btrfs-scrub.rst
+++ b/Documentation/btrfs-scrub.rst
@@ -69,7 +69,7 @@ resume [-BdqrR] <path>|<device>
 
 .. _man-scrub-start:
 
-start [-BdrRf] <path>|<device>
+start [options] <path>|<device>
         Start a scrub on all devices of the mounted filesystem identified by
         *path* or on a single *device*. If a scrub is already running, the new
         one will not start. A device of an unmounted filesystem cannot be
@@ -96,6 +96,17 @@ start [-BdrRf] <path>|<device>
                 can avoid writes from scrub.
         -R
                 raw print mode, print full data instead of summary
+	--limit <limit>
+		set the scrub throughput limit for each device.
+
+		If the scrub is for the whole fs, it's the same as
+		:command:`btrfs scrub limit -a -l <value>`.
+		If the scrub is for a single device, it's the same as
+		:command:`btrfs scrub limit -d <devid> -l <value>`.
+
+		The value is bytes per second, and accepts the usual KMGT prefixes.
+		After the scrub is finished, the throughput limit will be reset to
+		the old value of each device.
         -f
                 force starting new scrub even if a scrub is already running,
                 this can useful when scrub status file is damaged and reports a


### PR DESCRIPTION
I know there is already `btrfs scrub limit` command to set the limit, but a lot of users are not aware of that command.

Thus adding a new option `-t <throughput_limit>` to `btrfs scrub start`.

This has some extra behavior compared to `btrfs scrub limit`:

- Only set the value for the involved scrub device(s) If it's a full fs scrub, it will be the same as `btrfs scrub limit -a -l <value>`. If it's a single device, it will bt the same as `btrfs scrub limit -d <devid> -l <value>`.

- Automatically reset the limit after scrub is finished

- It only needs one single command line to set the limit

Issue: #943
Signed-off-by: Qu Wenruo <wqu@suse.com>
---
RFC:
I'm not sure if this is really needed since we already have `btrfs scrub limit`.
Involved tools like btrfs-maintenance scripts should have such support, but to my surprise, David introduced the `btrfs scrub limit` but not adding any support to btrfs-maintenance.