### PR TITLE
btrfs-progs: Expand abbreviations for clarity

### DIFF
--- a/Documentation/ch-volume-management-intro.rst
+++ b/Documentation/ch-volume-management-intro.rst
@@ -84,9 +84,9 @@ What changed:
 * available data space decreased by 3GiB, usable roughly (50 - 3) + (100 - 3) = 144 GiB
 * metadata redundancy increased
 
-IOW, the unequal device sizes allow for combined space for data yet improved
-redundancy for metadata. If we decide to increase redundancy of data as well,
-we're going to lose 50GiB of the second device for obvious reasons.
+In other words, the unequal device sizes allow for combined space for data yet
+improved redundancy for metadata. If we decide to increase redundancy of data as
+well, we're going to lose 50GiB of the second device for obvious reasons.
 
 .. code-block:: bash
 

--- a/kernel-shared/ctree.c
+++ b/kernel-shared/ctree.c
@@ -1867,9 +1867,8 @@ static int leaf_space_used(const struct extent_buffer *l, int start, int nr)
 }
 
 /*
- * The space between the end of the leaf items and
- * the start of the leaf data.  IOW, how much room
- * the leaf has left for both items and data
+ * The space between the end of the leaf items and the start of the leaf data.
+ * In other words, how much room the leaf has left for both items and data
  */
 int btrfs_leaf_free_space(const struct extent_buffer *leaf)
 {


### PR DESCRIPTION
Replace the use of IOW as abbreviation of "In other words" with the original expanded meaning, as users who don't have English as their first language may not know what it means.