### PR TITLE
btrfs-progs: mkfs: add break to case BTRFS_COMPRESS_NONE

### DIFF
--- a/mkfs/rootdir.c
+++ b/mkfs/rootdir.c
@@ -1654,6 +1654,7 @@ int btrfs_mkfs_fill_dir(struct btrfs_trans_handle *trans, const char *source_dir
 
 	switch (compression) {
 	case BTRFS_COMPRESS_NONE:
+                break;
 	case BTRFS_COMPRESS_LZO:
 #if !COMPRESSION_LZO
 		error("lzo support not compiled in");


### PR DESCRIPTION
when compression null, always through error "lzo support not compiled in"

This bug was imported by following commit:
-------------------
commit c6d24a363daed6501d13d9125c560387e2d755ca
Author: Mark Harmstone <maharmstone@fb.com>
Date:   Thu Dec 12 20:36:55 2024 +0000
-------------------
mkfs/rootdir.c:
int btrfs_mkfs_fill_dir(struct btrfs_trans_handle *trans, const char *source_dir,
                        struct btrfs_root *root, struct list_head *subvols,
                        enum btrfs_compression_type compression,
                        unsigned int compression_level)
{
        int ret;
        struct stat root_st;

        ret = lstat(source_dir, &root_st);
        if (ret) {
                error("unable to lstat %s: %m", source_dir);
                return -errno;
        }

        switch (compression) {
        case BTRFS_COMPRESS_NONE:
-------------------------------------------------------------------------------------
 //  When not select lzo, there will not stop and still check the following lzo.
--------------------------------------------------------------------------------------
        case BTRFS_COMPRESS_LZO:
