### PR TITLE
libbtrfsutil: update btrfs_util_create_snapshot doc

### DIFF
--- a/libbtrfsutil/btrfsutil.h
+++ b/libbtrfsutil/btrfsutil.h
@@ -553,7 +553,7 @@ LIBBTRFSUTIL_ALIAS(btrfs_util_create_subvolume_fd);
 #define BTRFS_UTIL_CREATE_SNAPSHOT_MASK		((1U << 2) - 1)
 
 /**
- * btrfs_util_create_snapshot() - Alias of btrfs_util_snapshot_snapshot(), do not use in new code.
+ * btrfs_util_create_snapshot() - Alias of btrfs_util_subvolume_snapshot(), do not use in new code.
  */
 enum btrfs_util_error btrfs_util_create_snapshot(const char *source,
 						 const char *path, int flags,


### PR DESCRIPTION
The alias should be for btrfs_util_subvolume_snapshot instead of btrfs_util_snapshot_snapshot.