### PR TITLE
!WIP! mkfs: copy verity metadata from the --rootdir

### DIFF
--- a/cmds/filesystem.c
+++ b/cmds/filesystem.c
@@ -1288,7 +1288,8 @@ static const char * const cmd_filesystem_resize_usage[] = {
 	NULL
 };
 
-static int check_resize_args(const char *amount, const char *path, u64 *devid_ret) {
+static int check_resize_args(const char *amount, const char *path, u64 *devid_ret)
+{
 	struct btrfs_ioctl_fs_info_args fi_args;
 	struct btrfs_ioctl_dev_info_args *di_args = NULL;
 	int ret, i, dev_idx = -1;
@@ -1421,15 +1422,16 @@ static int check_resize_args(const char *amount, const char *path, u64 *devid_re
 		}
 		new_size = round_down(new_size, fi_args.sectorsize);
 		res_str = pretty_size_mode(new_size, UNITS_DEFAULT);
+
+		if (new_size < 256 * SZ_1M)
+   warning("the new size %lld (%s) is < 256MiB, this may be rejected by kernel",
+			new_size, pretty_size_mode(new_size, UNITS_DEFAULT));
 	}
 
 	pr_verbose(LOG_DEFAULT, "Resize device id %lld (%s) from %s to %s\n", devid,
 		di_args[dev_idx].path,
 		pretty_size_mode(di_args[dev_idx].total_bytes, UNITS_DEFAULT),
 		res_str);
-	if (new_size < 256 * SZ_1M)
-		warning("the new size %lld (%s) is < 256MiB, this may be rejected by kernel",
-			new_size, pretty_size_mode(new_size, UNITS_DEFAULT));
 
 out:
 	free(di_args);

--- a/mkfs/main.c
+++ b/mkfs/main.c
@@ -442,6 +442,7 @@ static const char * const mkfs_usage[] = {
 	OPTLINE("-b|--byte-count SIZE", "set size of each device to SIZE (filesystem size is sum of all device sizes)"),
 	OPTLINE("-r|--rootdir DIR", "copy files from DIR to the image root directory, can be combined with --subvol"),
 	OPTLINE("--compress ALGO[:LEVEL]", "compress files by algorithm and level, ALGO can be 'no' (default), zstd, lzo, zlib"),
+	OPTLINE("--fs-verity", "copy fs-verity metadata from files in the --rootdir"),
 	OPTLINE("", "Built-in:"),
 #if COMPRESSION_ZSTD
 	OPTLINE("", "- ZSTD: yes (levels 1..15)"),
@@ -1206,6 +1207,7 @@ int BOX_MAIN(mkfs)(int argc, char **argv)
 	bool has_default_subvol = false;
 	enum btrfs_compression_type compression = BTRFS_COMPRESS_NONE;
 	unsigned int compression_level = 0;
+	bool fsverity = false;
 	LIST_HEAD(subvols);
 
 	cpu_detect_flags();
@@ -1221,6 +1223,7 @@ int BOX_MAIN(mkfs)(int argc, char **argv)
 			GETOPT_VAL_GLOBAL_ROOTS,
 			GETOPT_VAL_DEVICE_UUID,
 			GETOPT_VAL_COMPRESS,
+			GETOPT_VAL_FS_VERITY,
 		};
 		static const struct option long_options[] = {
 			{ "byte-count", required_argument, NULL, 'b' },
@@ -1249,6 +1252,8 @@ int BOX_MAIN(mkfs)(int argc, char **argv)
 			{ "shrink", no_argument, NULL, GETOPT_VAL_SHRINK },
 			{ "compress", required_argument, NULL,
 				GETOPT_VAL_COMPRESS },
+			{ "fs-verity", no_argument, NULL,
+				GETOPT_VAL_FS_VERITY },
 #if EXPERIMENTAL
 			{ "param", required_argument, NULL, GETOPT_VAL_PARAM },
 			{ "num-global-roots", required_argument, NULL, GETOPT_VAL_GLOBAL_ROOTS },
@@ -1377,6 +1382,9 @@ int BOX_MAIN(mkfs)(int argc, char **argv)
 					goto error;
 				}
 				break;
+			case GETOPT_VAL_FS_VERITY:
+				fsverity = true;
+				break;
 			case GETOPT_VAL_DEVICE_UUID:
 				strncpy_null(dev_uuid, optarg, BTRFS_UUID_UNPARSED_SIZE);
 				break;
@@ -1450,6 +1458,11 @@ int BOX_MAIN(mkfs)(int argc, char **argv)
 	} else {
 		if (compression != BTRFS_COMPRESS_NONE) {
 			error("--compression must be used with --rootdir");
+			ret = 1;
+			goto error;
+		}
+		if (fsverity) {
+			error("--fs-verity must be used with --rootdir");
 			ret = 1;
 			goto error;
 		}
@@ -2090,8 +2103,8 @@ raid_groups:
 		}
 
 		ret = btrfs_mkfs_fill_dir(trans, source_dir, root,
-					  &subvols, compression,
-					  compression_level);
+					  &subvols, fsverity,
+					  compression, compression_level);
 		if (ret) {
 			errno = -ret;
 			error("error while filling filesystem: %m");

--- a/mkfs/rootdir.h
+++ b/mkfs/rootdir.h
@@ -47,7 +47,7 @@ struct rootdir_subvol {
 
 int btrfs_mkfs_fill_dir(struct btrfs_trans_handle *trans, const char *source_dir,
 			struct btrfs_root *root, struct list_head *subvols,
-			enum btrfs_compression_type compression,
+			bool fsverity, enum btrfs_compression_type compression,
 			unsigned int compression_level);
 u64 btrfs_mkfs_size_dir(const char *dir_name, u32 sectorsize, u64 min_dev_size,
 			u64 meta_profile, u64 data_profile);


### PR DESCRIPTION
Add a new --fs-verity option.  If it's specified, then check if the regular files in the --rootdir have fs-verity enabled, and if they do, copy the metadata into the created filesystem.

We could have done this implicitly on creation of all filesystems, but I believe the new --fs-verity option is justified (over simply always checking) for a number of reasons:
 - (most importantly) if querying the fs-verity metadata on a file fails, we want to hear about it, loudly.  Querying fs-verity metadata on btrfs itself is only supported on kernel 6.14 and later, and on ext4 fs-verity isn't enabled by default.  We want to catch those cases and treat them as errors instead of silently proceeding.  If we were to always query fs-verity metadata then we'd have to ignore the unsupported cases.
 - tools and scripts invoking mkfs.btrfs and expecting the created filesystem to actually have fs-verity enabled on the relevant files need to be sure of this.  We want to fail if the new --fs-verity option isn't present.
 - most people are probably not interested in fs-verity data, and querying every single file (when no file has fs-verity enabled) would slow down filesystem creation
 - finally, doing this without an option would be a change in existing behaviour

Issue: #929


So far this works, but not for zero-size or inline files.

I'd love some feedback here on the implementation.  In particular, the way this fits in with the extents copying code is really awkward.  I'd like to share the fd that we open() but we don't open the file if it's empty.  I'd also maybe like to share the buffer.

My first thought would be to declare a separate buffer as a global and use it from both data copying and fs-verity copying.  This code is not multithreaded and already has a bunch of global variables, so it's not thread-safe anyway.  This would save the continuous `malloc()`/`free()`.  I'd also be happy to use a stack for this sort of thing: it's a large allocation (1MB) but it's in non-recursive application code, so it ought to be OK.

There's also a question if the fs-verity copy should happen inside of the extent-copying function or not.  That's where the fd is opened and I'd like to avoid opening the same file twice.  I think I might like to create a function which opens the fd and then calls the extent copying code and then the fs-verity copying code separately.  It's all a matter of taste and I'd like some input there.