### PR TITLE
[PATCH v3] btrfs-progs: add slack space for mkfs --shrink

### DIFF
--- a/mkfs/rootdir.h
+++ b/mkfs/rootdir.h
@@ -52,6 +52,6 @@ int btrfs_mkfs_fill_dir(struct btrfs_trans_handle *trans, const char *source_dir
 u64 btrfs_mkfs_size_dir(const char *dir_name, u32 sectorsize, u64 min_dev_size,
 			u64 meta_profile, u64 data_profile);
 int btrfs_mkfs_shrink_fs(struct btrfs_fs_info *fs_info, u64 *new_size_ret,
-			 bool shrink_file_size);
+			 bool shrink_file_size, u64 slack_size);
 
 #endif


### PR DESCRIPTION
This patch adds a flag `--shrink-slack-size SIZE` to the mkfs.btrfs allowing users to specify slack when shrinking the filesystem. Previously if you wanted to use --shrink and include extra space in the filesystem you would need to use btrfs resize, however, this requires mounting the filesystem which requires CAP_SYS_ADMIN.

The new syntax is:
`mkfs.btrfs --shrink --shrink-slack-size SIZE`

Where slack size is an argument specifying the desired free space to add to a shrunk fs. If not provided, the default slack size is 0.

V3:
- warn if block device size < fs size V2:
- change --shrink[=SLACK SIZE] to --shrink-slack-size SIZE
- check for slack size alignment
- fix formatting
- remove new_size > device size warning message