### PR TITLE
btrfs-progs: docs: fix kernel version to set defrag compress level

### DIFF
--- a/Documentation/btrfs-filesystem.rst
+++ b/Documentation/btrfs-filesystem.rst
@@ -118,7 +118,7 @@ defragment [options] <file>|<dir> [<file>|<dir>...]
                 compression. See also section *EXAMPLES*.
 
         -L|--level <level>
-                Since kernel 6.14 the compresison can also take the level parameter which will be used
+                Since kernel 6.15 the compresison can also take the level parameter which will be used
                 only for the defragmentation and overrides the eventual mount option compression level.
                 Valid levels depend on the compression algorithms: *zlib*
                 1..9, *lzo* does not have any levels, *zstd* the standard levels 1..15 and also the


### PR DESCRIPTION
I think this feature is provided by the commit https://github.com/torvalds/linux/commit/fc5c0c5825874859069ac44c367c724acd7190fb which is not included in 6.14.

It was not worked in my environment with 6.14.4 kernel.