### PR TITLE
btrfs-progs: device_get_partition_size*() enhancement and cleanup

### DIFF
--- a/check/main.c
+++ b/check/main.c
@@ -5447,7 +5447,13 @@ static int process_device_item(struct rb_root *dev_cache,
 				device->devid);
 			goto skip;
 		}
-		block_dev_size = device_get_partition_size_fd_stat(device->fd, &st);
+		ret = device_get_partition_size_fd_stat(device->fd, &st, &block_dev_size);
+		if (ret < 0) {
+			errno = -ret;
+			warning("failed to get device size for %s, skipping size check: %m",
+				device->name);
+			goto skip;
+		}
 		if (block_dev_size < rec->total_byte) {
 			error(
 "block device size is smaller than total_bytes in device item, has %llu expect >= %llu",

--- a/check/mode-lowmem.c
+++ b/check/mode-lowmem.c
@@ -4822,7 +4822,14 @@ next:
 			dev->devid);
 		return 0;
 	}
-	block_dev_size = device_get_partition_size_fd_stat(dev->fd, &st);
+	ret = device_get_partition_size_fd_stat(dev->fd, &st, &block_dev_size);
+	if (ret < 0) {
+		errno = -ret;
+		warning(
+	"failed to get device size for %s, skipping its block device size check: %m",
+			dev->name);
+		return 0;
+	}
 	if (block_dev_size < total_bytes) {
 		error(
 "block device size is smaller than total_bytes in device item, has %llu expect >= %llu",

--- a/cmds/filesystem-usage.c
+++ b/cmds/filesystem-usage.c
@@ -820,8 +820,14 @@ static int load_device_info(int fd, struct array *devinfos)
 			strcpy(info->path, "missing");
 		} else {
 			strcpy(info->path, (char *)dev_info.path);
-			info->device_size =
-				device_get_partition_size((const char *)dev_info.path);
+			ret = device_get_partition_size((const char *)dev_info.path,
+							&info->device_size);
+			if (ret < 0) {
+				errno = -ret;
+				warning("failed to get device size for %s: %m",
+					dev_info.path);
+				info->device_size = 0;
+			}
 		}
 		info->size = dev_info.total_bytes;
 		ndevs++;

--- a/cmds/filesystem-usage.c
+++ b/cmds/filesystem-usage.c
@@ -959,7 +959,6 @@ static void _cmd_filesystem_usage_tabular(unsigned unit_mode,
 		int k;
 		const char *p;
 		const struct device_info *devinfo = devinfos->data[i];
-
 		u64  total_allocated = 0, unused;
 
 		p = strrchr(devinfo->path, '/');
@@ -1000,7 +999,6 @@ static void _cmd_filesystem_usage_tabular(unsigned unit_mode,
 			col++;
 		}
 
-		unused = device_get_partition_size(devinfo->path) - total_allocated;
 		unused = devinfo->size - total_allocated;
 
 		table_printf(matrix, unallocated_col, vhdr_skip + i, ">%s",

--- a/cmds/replace.c
+++ b/cmds/replace.c
@@ -269,7 +269,12 @@ static int cmd_replace_start(const struct cmd_struct *cmd,
 		strncpy_null((char *)start_args.start.srcdev_name, srcdev,
 			     BTRFS_DEVICE_PATH_NAME_MAX + 1);
 		start_args.start.srcdevid = 0;
-		srcdev_size = device_get_partition_size(srcdev);
+		ret = device_get_partition_size(srcdev, &srcdev_size);
+		if (ret < 0) {
+			errno = -ret;
+			error("failed to get device size for %s: %m", srcdev);
+			goto leave_with_error;
+		}
 	} else {
 		error("source device must be a block device or a devid");
 		goto leave_with_error;
@@ -279,7 +284,12 @@ static int cmd_replace_start(const struct cmd_struct *cmd,
 	if (ret)
 		goto leave_with_error;
 
-	dstdev_size = device_get_partition_size(dstdev);
+	ret = device_get_partition_size(dstdev, &dstdev_size);
+	if (ret < 0) {
+		errno = -ret;
+		error("failed to get device size for %s: %m", dstdev);
+		goto leave_with_error;
+	}
 	if (srcdev_size > dstdev_size) {
 		error("target device smaller than source device (required %llu bytes)",
 			srcdev_size);

--- a/common/device-utils.c
+++ b/common/device-utils.c
@@ -369,7 +369,9 @@ static u64 device_get_partition_size_sysfs(const char *dev)
 		return 0;
 	}
 	close(sysfd);
-	return size;
+
+	/* <device>/size value is in sector (512B) unit. */
+	return size << SECTOR_SHIFT;
 }
 
 u64 device_get_partition_size(const char *dev)

--- a/common/device-utils.c
+++ b/common/device-utils.c
@@ -323,19 +323,6 @@ u64 device_get_partition_size_fd_stat(int fd, const struct stat *st)
 	return 0;
 }
 
-/*
- * Read partition size using the low-level ioctl
- */
-u64 device_get_partition_size_fd(int fd)
-{
-	u64 result;
-
-	if (ioctl(fd, BLKGETSIZE64, &result) < 0)
-		return 0;
-
-	return result;
-}
-
 static u64 device_get_partition_size_sysfs(const char *dev)
 {
 	int ret;

--- a/common/device-utils.h
+++ b/common/device-utils.h
@@ -42,7 +42,7 @@ enum {
  */
 int device_discard_blocks(int fd, u64 start, u64 len);
 int device_zero_blocks(int fd, off_t start, size_t len, const bool direct);
-u64 device_get_partition_size(const char *dev);
+int device_get_partition_size(const char *dev, u64 *size_ret);
 u64 device_get_partition_size_fd_stat(int fd, const struct stat *st);
 int device_get_queue_param(const char *file, const char *param, char *buf, size_t len);
 u64 device_get_zone_unusable(int fd, u64 flags);

--- a/common/device-utils.h
+++ b/common/device-utils.h
@@ -43,7 +43,6 @@ enum {
 int device_discard_blocks(int fd, u64 start, u64 len);
 int device_zero_blocks(int fd, off_t start, size_t len, const bool direct);
 u64 device_get_partition_size(const char *dev);
-u64 device_get_partition_size_fd(int fd);
 u64 device_get_partition_size_fd_stat(int fd, const struct stat *st);
 int device_get_queue_param(const char *file, const char *param, char *buf, size_t len);
 u64 device_get_zone_unusable(int fd, u64 flags);

--- a/common/device-utils.h
+++ b/common/device-utils.h
@@ -43,7 +43,7 @@ enum {
 int device_discard_blocks(int fd, u64 start, u64 len);
 int device_zero_blocks(int fd, off_t start, size_t len, const bool direct);
 int device_get_partition_size(const char *dev, u64 *size_ret);
-u64 device_get_partition_size_fd_stat(int fd, const struct stat *st);
+int device_get_partition_size_fd_stat(int fd, const struct stat *st, u64 *size_ret);
 int device_get_queue_param(const char *file, const char *param, char *buf, size_t len);
 u64 device_get_zone_unusable(int fd, u64 flags);
 u64 device_get_zone_size(int fd, const char *name);

--- a/image/common.c
+++ b/image/common.c
@@ -118,7 +118,12 @@ void write_backup_supers(int fd, u8 *buf)
 		return;
 	}
 
-	size = device_get_partition_size_fd_stat(fd, &st);
+	ret = device_get_partition_size_fd_stat(fd, &st, &size);
+	if (ret < 0) {
+		errno = -ret;
+		error("failed to get device size for backup supers: %m");
+		return;
+	}
 
 	for (i = 1; i < BTRFS_SUPER_MIRROR_MAX; i++) {
 		bytenr = btrfs_sb_offset(i);

--- a/kernel-shared/volumes.c
+++ b/kernel-shared/volumes.c
@@ -3096,8 +3096,13 @@ static int btrfs_fix_block_device_size(struct btrfs_fs_info *fs_info,
 		return -errno;
 	}
 
-	block_dev_size = round_down(device_get_partition_size_fd_stat(device->fd, &st),
-				    fs_info->sectorsize);
+	ret = device_get_partition_size_fd_stat(device->fd, &st, &block_dev_size);
+	if (ret < 0) {
+		errno = -ret;
+		error("failed to get device size for %s: %m", device->name);
+		return ret;
+	}
+	block_dev_size = round_down(block_dev_size, fs_info->sectorsize);
 
 	/*
 	 * Total_bytes in device item is no larger than the device block size,

--- a/mkfs/common.c
+++ b/mkfs/common.c
@@ -1167,35 +1167,6 @@ bool test_status_for_mkfs(const char *file, bool force_overwrite)
 	return false;
 }
 
-int is_vol_small(const char *file)
-{
-	int fd = -1;
-	int e;
-	struct stat st;
-	u64 size;
-
-	fd = open(file, O_RDONLY);
-	if (fd < 0)
-		return -errno;
-	if (fstat(fd, &st) < 0) {
-		e = -errno;
-		close(fd);
-		return e;
-	}
-	size = device_get_partition_size_fd_stat(fd, &st);
-	if (size == 0) {
-		close(fd);
-		return -1;
-	}
-	if (size < BTRFS_MKFS_SMALL_VOLUME_SIZE) {
-		close(fd);
-		return 1;
-	} else {
-		close(fd);
-		return 0;
-	}
-}
-
 int test_minimum_size(const char *file, u64 min_dev_size)
 {
 	int fd;

--- a/mkfs/common.c
+++ b/mkfs/common.c
@@ -1170,7 +1170,9 @@ bool test_status_for_mkfs(const char *file, bool force_overwrite)
 int test_minimum_size(const char *file, u64 min_dev_size)
 {
 	int fd;
+	int ret;
 	struct stat statbuf;
+	u64 size;
 
 	fd = open(file, O_RDONLY);
 	if (fd < 0)
@@ -1179,11 +1181,12 @@ int test_minimum_size(const char *file, u64 min_dev_size)
 		close(fd);
 		return -errno;
 	}
-	if (device_get_partition_size_fd_stat(fd, &statbuf) < min_dev_size) {
-		close(fd);
-		return 1;
-	}
+	ret = device_get_partition_size_fd_stat(fd, &statbuf, &size);
 	close(fd);
+	if (ret < 0)
+		return ret;
+	if (size < min_dev_size)
+		return 1;
 	return 0;
 }
 

--- a/mkfs/common.h
+++ b/mkfs/common.h
@@ -106,7 +106,6 @@ int make_btrfs(int fd, struct btrfs_mkfs_config *cfg);
 u64 btrfs_min_dev_size(u32 nodesize, bool mixed, u64 zone_size, u64 meta_profile,
 		       u64 data_profile);
 int test_minimum_size(const char *file, u64 min_dev_size);
-int is_vol_small(const char *file);
 int test_num_disk_vs_raid(u64 metadata_profile, u64 data_profile,
 	u64 dev_cnt, int mixed, int ssd);
 bool test_status_for_mkfs(const char *file, bool force_overwrite);


### PR DESCRIPTION
[CHANGELOG]
v2:
- Include and update Zoltan's fix to device_get_partition_size_sysfs()
  The "/dev/block/<device>/size" attribute is always in sector unit
  (512Bytes), independent from the physical device's block size.

  So the fix is pretty straightforward, just do the left shift before
  returning.

  And update the commit message to properly reflect that.

- Use s64 as the return value of device_get_partition_size*()
  Kernel ensures the max sector number of a device is LLONG_MAX >> 9,
  so s64 is more than enough to cover the device size, and we are safe
  to use the minus part to pass errors.

- Extra error handling when device_get_partition_size*() failed
  Ouput an error message and exit.
  Most callers are already doing that correctly but some are not.

- Keep the sysfs method as the fallback way to grab device size
  Since the device_get_partition_size_sysfs() can be easily fixed, no
  need to use complex path search for sector size.

- Add a new cleanup to remove is_vol_small()

Zoltan recently sent a fix to solve the bug in
device_get_partition_size_sysfs(), which is causing problems for "btrfs
dev usage".

It turns out that, the bug is just the attribute
"/sys/block/<device>/size" is in sector unit (512B), not in bytes.

So fix the bug first by reporting the correct size in bytes.

Then remove several unused functions exposed during the error handling
cleanup.

Finally cleanup device_get_partition_size*() helpers to provide a proper
error handling, not just return 0 for errors, but proper minus erro
code, and extra overflow check.