### PR TITLE
btrfs-progs: enhance --subvol/--inode-flags options

### DIFF
--- a/Documentation/mkfs.btrfs.rst
+++ b/Documentation/mkfs.btrfs.rst
@@ -243,11 +243,6 @@ OPTIONS
 	each subvolume is independent and will not inherit from the parent directory.
 	(The same as the kernel behavior.)
 
-        .. note::
-                Both *--inode-flags* and *--subvol* options are memory hungry,
-                will consume at least 8KiB for each option.  Please keep the
-                usage of both options to minimum.
-
 --shrink
         Shrink the filesystem to its minimal size, only works with *--rootdir* option.
 

--- a/mkfs/main.c
+++ b/mkfs/main.c
@@ -1527,50 +1527,9 @@ int BOX_MAIN(mkfs)(int argc, char **argv)
 		}
 	}
 
-	list_for_each_entry(rds, &subvols, list) {
-		char path[PATH_MAX];
-		struct rootdir_subvol *rds2;
-
-		if (path_cat_out(path, source_dir, rds->dir)) {
-			error("path invalid: %s", path);
-			ret = 1;
-			goto error;
-		}
-
-		if (!realpath(path, rds->full_path)) {
-			error("could not get canonical path: %s", rds->dir);
-			ret = 1;
-			goto error;
-		}
-
-		if (!path_exists(rds->full_path)) {
-			error("subvolume path does not exist: %s", rds->dir);
-			ret = 1;
-			goto error;
-		}
-
-		if (!path_is_dir(rds->full_path)) {
-			error("subvolume is not a directory: %s", rds->dir);
-			ret = 1;
-			goto error;
-		}
-
-		if (!path_is_in_dir(source_dir, rds->full_path)) {
-			error("subvolume %s is not a child of %s", rds->dir, source_dir);
-			ret = 1;
-			goto error;
-		}
-
-		for (rds2 = list_first_entry(&subvols, struct rootdir_subvol, list);
-		     rds2 != rds;
-		     rds2 = list_next_entry(rds2, list)) {
-			if (strcmp(rds2->full_path, rds->full_path) == 0) {
-				error("subvolume specified more than once: %s", rds->dir);
-				ret = 1;
-				goto error;
-			}
-		}
-	}
+	ret = btrfs_mkfs_validate_subvols(source_dir, &subvols);
+	if (ret < 0)
+		goto error;
 
 	list_for_each_entry(rif, &inode_flags_list, list) {
 		char path[PATH_MAX];

--- a/mkfs/rootdir.c
+++ b/mkfs/rootdir.c
@@ -1083,6 +1083,8 @@ int btrfs_mkfs_validate_subvols(const char *source_dir, struct list_head *subvol
 
 	list_for_each_entry(rds, subvols, list) {
 		char path[PATH_MAX];
+		char full_path[PATH_MAX];
+		struct stat stbuf;
 		struct rootdir_subvol *rds2;
 		int ret;
 
@@ -1092,21 +1094,29 @@ int btrfs_mkfs_validate_subvols(const char *source_dir, struct list_head *subvol
 			error("path invalid '%s': %m", path);
 			return ret;
 		}
-		if (!realpath(path, rds->full_path)) {
+		if (!realpath(path, full_path)) {
 			ret = -errno;
 			error("could not get canonical path of '%s': %m", rds->dir);
 			return ret;
 		}
-		ret = path_exists(rds->full_path);
+		ret = path_exists(full_path);
 		if (ret < 0) {
 			error("subvolume path does not exist: %s", rds->dir);
 			return ret;
 		}
-		ret = path_is_dir(rds->full_path);
+		ret = path_is_dir(full_path);
 		if (ret < 0) {
 			error("subvolume is not a directory: %s", rds->dir);
 			return ret;
 		}
+		ret = lstat(full_path, &stbuf);
+		if (ret < 0) {
+			ret = -errno;
+			error("failed to get stat of '%s': %m", full_path);
+			return ret;
+		}
+		rds->st_dev = stbuf.st_dev;
+		rds->st_ino = stbuf.st_ino;
 		list_for_each_entry(rds2, subvols, list) {
 			/*
 			 * Only compare entries before us, So we won't compare
@@ -1114,7 +1124,7 @@ int btrfs_mkfs_validate_subvols(const char *source_dir, struct list_head *subvol
 			 */
 			if (rds2 == rds)
 				break;
-			if (strcmp(rds2->full_path, rds->full_path) == 0) {
+			if (rds2->st_dev == rds->st_dev && rds2->st_ino == rds->st_ino) {
 				error("subvolume specified more than once: %s", rds->dir);
 				return -EINVAL;
 			}
@@ -1424,15 +1434,26 @@ static int ftw_add_subvol(const char *full_path, const struct stat *st,
 	struct btrfs_root *new_root;
 	struct inode_entry *parent;
 	struct btrfs_inode_item inode_item = { 0 };
+	char *path_dump;
+	char *base_path;
 	u64 subvol_id, ino;
 
 	subvol_id = next_subvol_id++;
+	path_dump = strdup(full_path);
+	if (!path_dump)
+		return -ENOMEM;
+	base_path = path_basename(path_dump);
+	if (!base_path) {
+		ret = -errno;
+		error("failed to get basename of '%s': %m", path_dump);
+		goto out;
+	}
 
 	ret = btrfs_make_subvolume(g_trans, subvol_id, subvol->readonly);
 	if (ret < 0) {
 		errno = -ret;
 		error("failed to create subvolume: %m");
-		return ret;
+		goto out;
 	}
 
 	if (subvol->is_default)
@@ -1447,19 +1468,18 @@ static int ftw_add_subvol(const char *full_path, const struct stat *st,
 		ret = PTR_ERR(new_root);
 		errno = -ret;
 		error("unable to read fs root id %llu: %m", subvol_id);
-		return ret;
+		goto out;
 	}
 
 	parent = rootdir_path_last(&current_path);
 
 	ret = btrfs_link_subvolume(g_trans, parent->root, parent->ino,
-				   path_basename(subvol->full_path),
-				   strlen(path_basename(subvol->full_path)),
+				   base_path, strlen(base_path),
 				   new_root);
 	if (ret) {
 		errno = -ret;
-		error("unable to link subvolume %s: %m", path_basename(subvol->full_path));
-		return ret;
+		error("unable to link subvolume %s: %m", base_path);
+		goto out;
 	}
 
 	ino = btrfs_root_dirid(&new_root->root_item);
@@ -1469,7 +1489,7 @@ static int ftw_add_subvol(const char *full_path, const struct stat *st,
 		errno = -ret;
 		error("failed to add xattr item for the top level inode in subvol %llu: %m",
 		      subvol_id);
-		return ret;
+		goto out;
 	}
 	stat_to_inode_item(&inode_item, st);
 
@@ -1479,7 +1499,7 @@ static int ftw_add_subvol(const char *full_path, const struct stat *st,
 	if (ret < 0) {
 		errno = -ret;
 		error("failed to update root dir for root %llu: %m", subvol_id);
-		return ret;
+		goto out;
 	}
 
 	ret = rootdir_path_push(&current_path, new_root, ino);
@@ -1487,10 +1507,12 @@ static int ftw_add_subvol(const char *full_path, const struct stat *st,
 		errno = -ret;
 		error("failed to allocate new entry for subvolume %llu ('%s'): %m",
 		      subvol_id, full_path);
-		return ret;
+		goto out;
 	}
 
-	return 0;
+out:
+	free(path_dump);
+	return ret;
 }
 
 static int read_inode_item(struct btrfs_root *root, struct btrfs_inode_item *inode_item,
@@ -1611,7 +1633,7 @@ static int ftw_add_inode(const char *full_path, const struct stat *st,
 
 	if (S_ISDIR(st->st_mode)) {
 		list_for_each_entry(rds, g_subvols, list) {
-			if (!strcmp(full_path, rds->full_path)) {
+			if (st->st_dev == rds->st_dev && st->st_ino == rds->st_ino) {
 				ret = ftw_add_subvol(full_path, st, typeflag,
 						     ftwbuf, rds);
 

--- a/mkfs/rootdir.h
+++ b/mkfs/rootdir.h
@@ -41,7 +41,9 @@ struct rootdir_subvol {
 	struct list_head list;
 	/* The path inside the source_dir. */
 	char dir[PATH_MAX];
-	char full_path[PATH_MAX];
+	/* st_dev and st_ino is going to uniquely determine an inode inside the host fs. */
+	dev_t st_dev;
+	ino_t st_ino;
 	bool is_default;
 	bool readonly;
 };

--- a/mkfs/rootdir.h
+++ b/mkfs/rootdir.h
@@ -39,6 +39,7 @@ struct btrfs_root;
 
 struct rootdir_subvol {
 	struct list_head list;
+	/* The path inside the source_dir. */
 	char dir[PATH_MAX];
 	char full_path[PATH_MAX];
 	bool is_default;
@@ -59,6 +60,7 @@ struct rootdir_inode_flags_entry {
 	bool nodatasum;
 };
 
+int btrfs_mkfs_validate_subvols(const char *source_dir, struct list_head *subvols);
 int btrfs_mkfs_fill_dir(struct btrfs_trans_handle *trans, const char *source_dir,
 			struct btrfs_root *root, struct list_head *subvols,
 			struct list_head *inode_flags_list,

--- a/mkfs/rootdir.h
+++ b/mkfs/rootdir.h
@@ -49,14 +49,15 @@ struct rootdir_subvol {
 };
 
 /*
- * Represent a flag for specified inode at @full_path.
+ * Represent a flag for specified inode at "$source_dir/$inode_path".
  */
 struct rootdir_inode_flags_entry {
 	struct list_head list;
-	/* Fully canonicalized path to the source file. */
-	char full_path[PATH_MAX];
 	/* Path inside the source directory. */
 	char inode_path[PATH_MAX];
+	/* st_dev and st_ino is going to uniquely determine an inode inside the host fs. */
+	dev_t st_dev;
+	ino_t st_ino;
 
 	bool nodatacow;
 	bool nodatasum;

--- a/mkfs/rootdir.h
+++ b/mkfs/rootdir.h
@@ -61,6 +61,7 @@ struct rootdir_inode_flags_entry {
 };
 
 int btrfs_mkfs_validate_subvols(const char *source_dir, struct list_head *subvols);
+int btrfs_mkfs_validate_inode_flags(const char *source_dir, struct list_head *inode_flags);
 int btrfs_mkfs_fill_dir(struct btrfs_trans_handle *trans, const char *source_dir,
 			struct btrfs_root *root, struct list_head *subvols,
 			struct list_head *inode_flags_list,


### PR DESCRIPTION
Currently both --subvol and --inode-flags save the full path into their
structures, and check each inode against those full path.

For long paths it can be time consuming, and this introduces extra
memory for each structure.

This series enhance the handling of those options by:

- Extract the validation part into a dedicated helper inside
  rootdir.[ch]

- Use st_dev/st_ino to replace full_path
  This reduces runtime and memory usage for the involved structures.

- Remove the memory usage warning note
  Even with the old 8K per structure memory usage, 1024 options will
  only 8M memory, that's accetable even for a lot of micro-controllers,
  not to mention modern desktop/servers.

  I'm a little paranoid at that time, with the memory usage almost
  halved, we can safely remove that warning note.