### PR TITLE
btrfs-progs: print-tree: add support for verity compat_ro flag

### DIFF
--- a/kernel-shared/print-tree.c
+++ b/kernel-shared/print-tree.c
@@ -1915,6 +1915,7 @@ static int check_csum_sblock(void *sb, int csum_size, u16 csum_type)
 static struct readable_flag_entry compat_ro_flags_array[] = {
 	DEF_COMPAT_RO_FLAG_ENTRY(FREE_SPACE_TREE),
 	DEF_COMPAT_RO_FLAG_ENTRY(FREE_SPACE_TREE_VALID),
+	DEF_COMPAT_RO_FLAG_ENTRY(VERITY),
 	DEF_COMPAT_RO_FLAG_ENTRY(BLOCK_GROUP_TREE),
 };
 static const int compat_ro_flags_num = ARRAY_SIZE(compat_ro_flags_array);


### PR DESCRIPTION
The super block dumping is not handling verity compat ro flags correctly, it always treats verity as an unknown flag:

compat_ro_flags		0x7
			( FREE_SPACE_TREE |
			  FREE_SPACE_TREE_VALID |
			  unknown flag: 0x4 )

Add the readable flags for verity feature.

Issue: #1040