### PR TITLE
scrub: Avoid wraparound in ETA calculation

### DIFF
--- a/cmds/scrub.c
+++ b/cmds/scrub.c
@@ -169,7 +169,7 @@ static void print_scrub_summary(struct btrfs_scrub_progress *p, struct scrub_sta
 		bytes_per_sec = bytes_scrubbed;
 	else
 		bytes_per_sec = bytes_scrubbed / s->duration;
-	if (bytes_per_sec > 0)
+	if (bytes_per_sec > 0 && bytes_total >= bytes_scrubbed)
 		sec_left = (bytes_total - bytes_scrubbed) / bytes_per_sec;
 
 	err_cnt = p->read_errors +


### PR DESCRIPTION
This is only a trivial patch to the scrub logging UI.

If the user deletes a significant amount of data during an ongoing scrub, `bytes_scrubbed` may exceed `bytes_total`, and it results in an unreasonable ETA estimation that might confuse users.
This patch pegs the ETA to 0 when such an underflow happens.