### PR TITLE
btrfs-progs: add offline conversion to remap tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -289,7 +289,8 @@ mkfs_objects = mkfs/main.o mkfs/common.o mkfs/rootdir.o
 image_objects = image/main.o image/sanitize.o image/image-create.o image/common.o \
 		image/image-restore.o
 tune_objects = tune/main.o tune/seeding.o tune/change-uuid.o tune/change-metadata-uuid.o \
-	       tune/convert-bgt.o tune/change-csum.o common/clear-cache.o tune/quota.o
+	       tune/convert-bgt.o tune/change-csum.o common/clear-cache.o tune/quota.o \
+	       tune/convert-remap-tree.o
 all_objects = $(objects) $(cmds_objects) $(libbtrfs_objects) $(convert_objects) \
 	      $(mkfs_objects) $(image_objects) $(tune_objects) $(libbtrfsutil_objects)
 

--- a/kernel-shared/disk-io.c
+++ b/kernel-shared/disk-io.c
@@ -2269,6 +2269,7 @@ int write_ctree_super(struct btrfs_trans_handle *trans)
 	struct btrfs_fs_info *fs_info = trans->fs_info;
 	struct btrfs_root *tree_root = fs_info->tree_root;
 	struct btrfs_root *chunk_root = fs_info->chunk_root;
+	struct btrfs_root *remap_root = fs_info->remap_root;
 
 	if (fs_info->readonly)
 		return 0;
@@ -2285,6 +2286,15 @@ int write_ctree_super(struct btrfs_trans_handle *trans)
 					 btrfs_header_level(chunk_root->node));
 	btrfs_set_super_chunk_root_generation(fs_info->super_copy,
 				btrfs_header_generation(chunk_root->node));
+
+	if (btrfs_fs_incompat(fs_info, REMAP_TREE)) {
+		btrfs_set_super_remap_root(fs_info->super_copy,
+					   remap_root->node->start);
+		btrfs_set_super_remap_root_level(fs_info->super_copy,
+					btrfs_header_level(remap_root->node));
+		btrfs_set_super_remap_root_generation(fs_info->super_copy,
+				btrfs_header_generation(remap_root->node));
+	}
 
 	ret = write_all_supers(fs_info);
 	if (ret)

--- a/tests/misc-tests/071-btrfstune-enable-remap-tree/test.sh
+++ b/tests/misc-tests/071-btrfstune-enable-remap-tree/test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Test btrfstune --convert-to-remap-tree option
+
+source "$TEST_TOP/common" || exit
+source "$TEST_TOP/common.convert" || exit
+
+check_experimental_build
+check_prereq mkfs.btrfs
+check_prereq btrfstune
+check_prereq btrfs
+
+setup_root_helper
+prepare_test_dev
+
+run_check_mkfs_test_dev -O ^remap-tree
+run_check_mount_test_dev
+populate_fs
+run_check_umount_test_dev
+
+run_check $SUDO_HELPER "$TOP/btrfstune" --convert-to-remap-tree "$TEST_DEV"
+
+run_check "$TOP/btrfs" check "$TEST_DEV"

--- a/tune/convert-remap-tree.c
+++ b/tune/convert-remap-tree.c
@@ -1,0 +1,207 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License v2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 021110-1307, USA.
+ */
+
+#include "common/messages.h"
+#include "kernel-shared/transaction.h"
+#include "kernel-shared/disk-io.h"
+#include "kernel-shared/volumes.h"
+#include "tune/tune.h"
+
+static int remove_data_reloc_tree(struct btrfs_trans_handle *trans)
+{
+	struct btrfs_fs_info *fs_info = trans->fs_info;
+	struct btrfs_root *root;
+	int ret;
+
+	struct btrfs_key key = {
+		.objectid = BTRFS_DATA_RELOC_TREE_OBJECTID,
+		.type = BTRFS_ROOT_ITEM_KEY,
+		.offset = 0,
+	};
+
+	root = btrfs_read_fs_root(fs_info, &key);
+	if (IS_ERR(root))
+		return PTR_ERR(root);
+
+	/*
+	 * We've already made sure there's not a balance in progress,
+	 * double-check that we're not going to mess things up because the
+	 * tree has multiple leaves.
+	 */
+	assert(btrfs_header_level(root->node) == 0);
+
+	rb_erase(&root->rb_node, &fs_info->fs_root_tree);
+
+	ret = btrfs_delete_and_free_root(trans, root);
+	if (ret)
+		return ret;
+
+	return 0;
+}
+
+static int create_remap_tree(struct btrfs_trans_handle *trans)
+{
+	struct btrfs_fs_info *fs_info = trans->fs_info;
+	struct btrfs_super_block *sb = fs_info->super_copy;
+	struct btrfs_root *root;
+	u64 bg_flags, chunk_start, chunk_size;
+	int ret;
+
+	struct btrfs_key key = {
+		.objectid = BTRFS_REMAP_TREE_OBJECTID,
+		.type = BTRFS_ROOT_ITEM_KEY,
+		.offset = 0,
+	};
+
+	bg_flags = BTRFS_BLOCK_GROUP_METADATA_REMAP;
+	bg_flags |= fs_info->avail_metadata_alloc_bits &
+			fs_info->metadata_alloc_profile;
+
+	ret = btrfs_alloc_chunk(trans, fs_info, &chunk_start, &chunk_size,
+				bg_flags);
+	if (ret)
+		return ret;
+
+	ret = btrfs_make_block_group(trans, fs_info, 0, bg_flags,
+				     chunk_start, chunk_size);
+	if (ret)
+		return ret;
+
+	root = btrfs_create_tree(trans, &key);
+	if (IS_ERR(root))
+		return PTR_ERR(root);
+
+	btrfs_set_super_remap_root(sb, root->root_item.bytenr);
+	btrfs_set_super_remap_root_generation(sb, root->root_item.generation);
+	btrfs_set_super_remap_root_level(sb, root->root_item.level);
+
+	kfree(fs_info->remap_root);
+	fs_info->remap_root = root;
+
+	add_root_to_dirty_list(root);
+
+	return 0;
+}
+
+static int extend_block_group_items(struct btrfs_trans_handle *trans)
+{
+	struct btrfs_fs_info *fs_info = trans->fs_info;
+	struct btrfs_path path = { 0 };
+	struct btrfs_key key = { 0 };
+	struct extent_buffer *leaf;
+	struct btrfs_block_group_item_v2 *bgi;
+	int ret;
+	u32 size;
+
+	while (true) {
+		ret = btrfs_search_slot(trans, fs_info->block_group_root,
+					&key, &path, -1, 1);
+		if (ret < 0)
+			return ret;
+
+		leaf = path.nodes[0];
+
+		if (path.slots[0] >= btrfs_header_nritems(leaf)) {
+			btrfs_release_path(&path);
+			break;
+		}
+
+		while (path.slots[0] < btrfs_header_nritems(leaf)) {
+			btrfs_item_key_to_cpu(leaf, &key, path.slots[0]);
+
+			assert(key.type == BTRFS_BLOCK_GROUP_ITEM_KEY);
+
+			size = btrfs_item_size(leaf, path.slots[0]);
+
+			assert(size == sizeof(struct btrfs_block_group_item));
+
+			btrfs_extend_item(&path,
+				sizeof(struct btrfs_block_group_item_v2) - size);
+
+			leaf = path.nodes[0];
+
+			bgi = btrfs_item_ptr(leaf, path.slots[0],
+					     struct btrfs_block_group_item_v2);
+
+			btrfs_set_block_group_v2_remap_bytes(leaf, bgi, 0);
+			btrfs_set_block_group_v2_identity_remap_count(leaf, bgi, 0);
+
+			path.slots[0]++;
+		}
+
+		key.objectid++;
+		key.offset = 0;
+
+		btrfs_release_path(&path);
+	}
+
+	return 0;
+}
+
+int convert_to_remap_tree(struct btrfs_fs_info *fs_info)
+{
+	struct btrfs_super_block *sb = fs_info->super_copy;
+	struct btrfs_trans_handle *trans;
+	struct btrfs_path path = { 0 };
+	struct btrfs_key key;
+	int ret;
+
+	key.objectid = BTRFS_BALANCE_OBJECTID;
+	key.type = BTRFS_BALANCE_ITEM_KEY;
+	key.offset = 0;
+	ret = btrfs_search_slot(NULL, fs_info->tree_root, &key, &path, 0, 0);
+	if (ret < 0)
+		return ret;
+
+	if (!ret) {
+		error("Can't convert filesystem that has balance already in progress");
+		btrfs_release_path(&path);
+		return -EINVAL;
+	}
+
+	btrfs_release_path(&path);
+
+	trans = btrfs_start_transaction(fs_info->tree_root, 0);
+	if (IS_ERR(trans))
+		return PTR_ERR(trans);
+
+	ret = remove_data_reloc_tree(trans);
+	if (ret)
+		goto fail;
+
+	ret = create_remap_tree(trans);
+	if (ret)
+		goto fail;
+
+	ret = extend_block_group_items(trans);
+	if (ret)
+		goto fail;
+
+	btrfs_set_super_incompat_flags(sb, btrfs_super_incompat_flags(sb) |
+		BTRFS_FEATURE_INCOMPAT_REMAP_TREE);
+
+	ret = btrfs_commit_transaction(trans, fs_info->tree_root);
+	if (ret)
+		goto fail;
+
+	pr_verbose(LOG_DEFAULT, "Converted filesystem to remap tree feature\n");
+
+	return ret;
+
+fail:
+	btrfs_abort_transaction(trans, ret);
+	return ret;
+}

--- a/tune/tune.h
+++ b/tune/tune.h
@@ -37,4 +37,6 @@ int btrfs_change_csum_type(struct btrfs_fs_info *fs_info, u16 new_csum_type);
 int enable_quota(struct btrfs_fs_info *fs_info, bool simple);
 int remove_squota(struct btrfs_fs_info *fs_info);
 
+int convert_to_remap_tree(struct btrfs_fs_info *fs_info);
+
 #endif


### PR DESCRIPTION
Add an option `--convert-to-remap-tree` to btrfstune, which converts a filesystem to use the new remap tree feature. There's no `--convert-from-remap-tree` yet, as it's considerably more complicated: it implies undoing any remappings that have already taken place.

This does the following:

* Enables the block group tree and free space tree, if these aren't already set
* Sets the remap tree incompat flag
* Removes the data reloc tree
* Creates a METADATA_REMAP block group
* Creates an empty remap tree
* Extends the block group items to their new form