### PR TITLE
btrfs-progs: check: recognize verity item keys in original mode

### DIFF
--- a/check/main.c
+++ b/check/main.c
@@ -1895,6 +1895,9 @@ static int process_one_leaf(struct btrfs_root *root, struct extent_buffer *eb,
 		case BTRFS_XATTR_ITEM_KEY:
 			ret = process_xattr_item(eb, i, &key, active_node);
 			break;
+		case BTRFS_VERITY_DESC_ITEM_KEY:
+		case BTRFS_VERITY_MERKLE_ITEM_KEY:
+			break;
 		default:
 			error("unknown key (%llu %u %llu) found in leaf %llu",
 			      key.objectid, key.type, key.offset, eb->start);


### PR DESCRIPTION
Commit 4e88bb6e ("btrfs-progs: enhance detection on unknown inode keys") added stricter validation for inode keys in the original mode checker, flagging unknown key types as errors. However, it did not add cases for BTRFS_VERITY_DESC_ITEM_KEY (36) and BTRFS_VERITY_MERKLE_ITEM_KEY (37), causing any filesystem with fs-verity enabled files to fail the check with:

  ERROR: unknown key (257 36 0) found in leaf 30621696

Add the missing switch cases so that verity metadata items are recognized and silently skipped during the check, matching the behavior of lowmem mode which already handles them.