### PR TITLE
btrfs-progs: add missing error handling for strdup()

### DIFF
--- a/btrfs-map-logical.c
+++ b/btrfs-map-logical.c
@@ -263,6 +263,10 @@ int main(int argc, char **argv)
 				break;
 			case 'o':
 				output_file = strdup(optarg);
+				if (!output_file) {
+					error_mem(NULL);
+					return 1;
+				}
 				break;
 			default:
 				usage(&map_logical_cmd, 1);

--- a/btrfs-sb-mod.c
+++ b/btrfs-sb-mod.c
@@ -415,6 +415,11 @@ int main(int argc, char **argv)
 		f = &spec[specidx];
 		specidx++;
 		f->name = strdup(argv[i]);
+		if (!f->name) {
+			ret = 1;
+			error_mem(NULL);
+			goto out;
+		}
 		i++;
 		if (arg_to_op_value(argv[i], &f->fop, &f->value)) {
 			ret = 1;

--- a/cmds/inspect.c
+++ b/cmds/inspect.c
@@ -1063,6 +1063,11 @@ static int cmd_inspect_list_chunks(const struct cmd_struct *cmd,
 		case GETOPT_VAL_SORT:
 			free(sortmode);
 			sortmode = strdup(optarg);
+			if (!sortmode) {
+				ret = 1;
+				error_mem(NULL);
+				goto out;
+			}
 			break;
 		default:
 			usage_unknown_option(cmd, argv);

--- a/common/utils.c
+++ b/common/utils.c
@@ -632,6 +632,10 @@ int find_mount_fsroot(const char *subvol, const char *subvolid, char **mount)
 				goto out;
 			found = true;
 			*mount = strdup(ent.path);
+			if (!*mount) {
+				ret = -ENOMEM;
+				goto out;
+			}
 			ret = 0;
 			goto nextline;
 		}
@@ -952,8 +956,18 @@ void bconf_add_param(const char *key, const char *value)
 	if (!param)
 		return;
 	param->key = strdup(key);
-	if (value)
+	if (!param->key) {
+		free(param);
+		return;
+	}
+	if (value) {
 		param->value = strdup(value);
+		if (!param->value) {
+			free(param->key);
+			free(param);
+			return;
+		}
+	}
 	list_add(&param->list, &bconf.params);
 }
 

--- a/convert/main.c
+++ b/convert/main.c
@@ -1983,6 +1983,10 @@ int BOX_MAIN(convert)(int argc, char *argv[])
 				break;
 			case 'O': {
 				char *orig = strdup(optarg);
+				if (!orig) {
+					error_mem(NULL);
+					exit(1);
+				}
 				char *tmp = orig;
 
 				tmp = btrfs_parse_fs_features(tmp, &features);


### PR DESCRIPTION
Add proper error handling for strdup() calls that were missing
NULL checks. This prevents potential NULL pointer dereferences
when memory allocation fails.

## Files Changed:
- `btrfs-map-logical.c`: output_file = strdup(optarg)
- `btrfs-sb-mod.c`: f->name = strdup(argv[i])
- `cmds/inspect.c`: sortmode = strdup(optarg)
- `common/utils.c`: *mount = strdup(ent.path)
- `common/utils.c`: param->key = strdup(key) and param->value = strdup(value)

## Context:
Similar issues were fixed in commit b6c342bf ("libbtrfs: handle memory
allocation errors when searching uuids").

This follows the same pattern of adding proper error handling for
memory allocation failures, which could otherwise lead to NULL pointer
dereferences.