### PR TITLE
btrfs receive: add --fsync and --syncfs options

### DIFF
--- a/Documentation/btrfs-receive.rst
+++ b/Documentation/btrfs-receive.rst
@@ -62,6 +62,14 @@ A subvolume is made read-only after the receiving process finishes successfully 
         :doc:`btrfs-send`), always decompress it instead of writing it with
         encoded I/O
 
+--fsync
+        perform fsync for each received file to make sure the data is
+        persisted to disk before finishing
+
+--syncfs
+        perform syncfs on the destination filesystem after receiving to
+        make sure all data is persisted to disk
+
 --dump
         dump the stream metadata, one line per operation
 

--- a/cmds/receive.c
+++ b/cmds/receive.c
@@ -81,6 +81,8 @@ struct btrfs_receive
 	bool honor_end_cmd;
 
 	bool force_decompress;
+	bool fsync_on_close;
+	bool syncfs_on_finish;
 
 #if COMPRESSION_ZSTD
 	/* Reuse stream objects for encoded_write decompression fallback */
@@ -659,6 +661,38 @@ out:
 	return ret;
 }
 
+static int close_inode_for_write(struct btrfs_receive *rctx)
+{
+	int ret = 0;
+
+	if(rctx->write_fd == -1)
+		return 0;
+
+	/*
+	 * Encoded writes (used for compressed extents in send stream v2)
+	 * are asynchronous in the kernel — the ioctl returns success
+	 * before the data hits disk. If the bio fails (e.g. due to memory
+	 * corruption or hardware errors), the error is only stored on the
+	 * inode's address_space and is not reported to userspace unless
+	 * fsync() is called. Without this fsync, corrupted files with
+	 * zero-filled holes can be silently accepted by btrfs receive.
+	 */
+	if (rctx->fsync_on_close && fsync(rctx->write_fd) < 0) {
+		ret = -errno;
+		error("fsync on %s failed: %m", rctx->write_path);
+	}
+
+	if (close(rctx->write_fd) < 0) {
+		if (!ret) {
+			ret = -errno;
+			error("close on %s failed: %m", rctx->write_path);
+		}
+	}
+	rctx->write_fd = -1;
+	rctx->write_path[0] = 0;
+	return ret;
+}
+
 static int open_inode_for_write(struct btrfs_receive *rctx, const char *path)
 {
 	int ret = 0;
@@ -666,8 +700,9 @@ static int open_inode_for_write(struct btrfs_receive *rctx, const char *path)
 	if (rctx->write_fd != -1) {
 		if (strcmp(rctx->write_path, path) == 0)
 			goto out;
-		close(rctx->write_fd);
-		rctx->write_fd = -1;
+		ret = close_inode_for_write(rctx);
+		if (ret < 0)
+			goto out;
 	}
 
 	rctx->write_fd = open(path, O_RDWR);
@@ -680,16 +715,6 @@ static int open_inode_for_write(struct btrfs_receive *rctx, const char *path)
 
 out:
 	return ret;
-}
-
-static void close_inode_for_write(struct btrfs_receive *rctx)
-{
-	if(rctx->write_fd == -1)
-		return;
-
-	close(rctx->write_fd);
-	rctx->write_fd = -1;
-	rctx->write_path[0] = 0;
 }
 
 static int process_write(const char *path, const void *data, u64 offset,
@@ -1418,13 +1443,16 @@ static int process_enable_verity(const char *path, u8 algorithm, u32 block_size,
 	 * Enabling verity denies write access, so it cannot be done with an
 	 * open writeable file descriptor.
 	 */
-	close_inode_for_write(rctx);
+	ret = close_inode_for_write(rctx);
+	if (ret < 0)
+		goto close_ioctl_fd;
 	ret = ioctl(ioctl_fd, FS_IOC_ENABLE_VERITY, &verity_args);
 	if (ret < 0) {
 		ret = -errno;
 		error("failed to enable verity on %s: %d", full_path, ret);
 	}
 
+close_ioctl_fd:
 	close(ioctl_fd);
 out:
 	return ret;
@@ -1593,7 +1621,9 @@ static int do_receive(struct btrfs_receive *rctx, const char *tomnt,
 		if (ret > 0)
 			end = true;
 
-		close_inode_for_write(rctx);
+		ret = close_inode_for_write(rctx);
+		if (ret < 0)
+			goto out;
 		ret = finish_subvol(rctx);
 		if (ret < 0)
 			goto out;
@@ -1604,8 +1634,25 @@ static int do_receive(struct btrfs_receive *rctx, const char *tomnt,
 
 out:
 	if (rctx->write_fd != -1) {
-		close(rctx->write_fd);
-		rctx->write_fd = -1;
+		int err = close_inode_for_write(rctx);
+
+		if (!ret)
+			ret = err;
+	}
+
+	/*
+	 * syncfs on the destination filesystem to make sure all data is
+	 * persisted to disk. This catches any IO errors that happened
+	 * asynchronously, including those from encoded writes.
+	 */
+	if (rctx->syncfs_on_finish && rctx->dest_dir_fd != -1) {
+		if (syncfs(rctx->dest_dir_fd) < 0) {
+			int err = -errno;
+
+			error("syncfs on destination failed: %m");
+			if (!ret)
+				ret = err;
+		}
 	}
 
 	if (rctx->root_path != realmnt)
@@ -1660,6 +1707,10 @@ static const char * const cmd_receive_usage[] = {
 		"this file system is mounted."),
 	OPTLINE("--force-decompress", "if the stream contains compressed data, always "
 		"decompress it instead of writing it with encoded I/O"),
+	OPTLINE("--fsync", "perform fsync for each received file to make sure "
+		"the data is persisted to disk before finishing"),
+	OPTLINE("--syncfs", "perform syncfs on the destination filesystem after "
+		"receiving to make sure all data is persisted to disk"),
 	OPTLINE("--dump", "dump stream metadata, one line per operation, "
 		"does not require the MOUNT parameter"),
 	OPTLINE("-v", "deprecated, alias for global -v option"),
@@ -1720,6 +1771,8 @@ static int cmd_receive(const struct cmd_struct *cmd, int argc, char **argv)
 		enum {
 			GETOPT_VAL_DUMP = GETOPT_VAL_FIRST,
 			GETOPT_VAL_FORCE_DECOMPRESS,
+			GETOPT_VAL_FSYNC,
+			GETOPT_VAL_SYNCFS,
 		};
 		static const struct option long_opts[] = {
 			{ "max-errors", required_argument, NULL, 'E' },
@@ -1727,6 +1780,8 @@ static int cmd_receive(const struct cmd_struct *cmd, int argc, char **argv)
 			{ "dump", no_argument, NULL, GETOPT_VAL_DUMP },
 			{ "quiet", no_argument, NULL, 'q' },
 			{ "force-decompress", no_argument, NULL, GETOPT_VAL_FORCE_DECOMPRESS },
+			{ "fsync", no_argument, NULL, GETOPT_VAL_FSYNC },
+			{ "syncfs", no_argument, NULL, GETOPT_VAL_SYNCFS },
 			{ NULL, 0, NULL, 0 }
 		};
 
@@ -1771,6 +1826,12 @@ static int cmd_receive(const struct cmd_struct *cmd, int argc, char **argv)
 			break;
 		case GETOPT_VAL_FORCE_DECOMPRESS:
 			rctx.force_decompress = true;
+			break;
+		case GETOPT_VAL_FSYNC:
+			rctx.fsync_on_close = true;
+			break;
+		case GETOPT_VAL_SYNCFS:
+			rctx.syncfs_on_finish = true;
 			break;
 		default:
 			usage_unknown_option(cmd, argv);


### PR DESCRIPTION
## Summary

  Encoded writes were silently ignoring write errors. This is fixed on the kernel side in https://lore.kernel.org/lkml/20260330160644.3678224-1-mge@meta.com/. This change augments that fix with optional fsync/syncfs support so users can enable strict checks on data write durability.

  New flags:
  - `--fsync` — fsyncs each file before closing during receive, ensuring data is persisted and detecting async I/O errors early at the individual file level. Higher I/O overhead but pinpoints the exact file that failed.
  - `--syncfs` — calls `syncfs()` on the destination filesystem after receiving, catching any remaining unflushed writeback errors in a single operation. Lower overhead but only reports errors at the end.

  Both flags require the kernel-side fix to be effective — on unfixed kernels, encoded write errors are silently dropped and never flagged, so neither `fsync` nor `syncfs` will detect them.

  ## Test plan

  Tested with a dm-flakey device returning write errors after 100MB offset on a 2GB device on a kernel with the fix.

  **Without flags** — error is only caught late, at the final `BTRFS_IOC_SET_RECEIVED_SUBVOL` ioctl:
  === Test: no sync flags ===
  At subvol volume
  ERROR: ioctl BTRFS_IOC_SET_RECEIVED_SUBVOL failed: Input/output error

  **With `--syncfs`** — same late error, plus `syncfs` also reports the failure:
  === Test: with --syncfs ===
  At subvol volume
  ERROR: ioctl BTRFS_IOC_SET_RECEIVED_SUBVOL failed: Input/output error
  ERROR: syncfs on destination failed: Input/output error

  **With `--fsync`** — error is caught early at the specific file that failed:
  === Test: with --fsync ===
  At subvol volume
  ERROR: fsync on /tmp/flakey-mnt//volume/.meta/private/opts/artifacts_may_require_repo failed: Input/output error

  <details>
  <summary>Test script (dm-flakey setup)</summary>

  ```bash
  #!/bin/bash
  set -euo pipefail

  # Creates a device that works normally for the first N MB
  # and returns I/O errors for all writes beyond that.
  # Uses dm-linear + dm-flakey to simulate partial disk failure.
  #
  # Usage: sudo ./flakey.sh <sendstream> [size] [good_size_mb]
  # Cleanup: sudo ./flakey.sh --cleanup

  SENDSTREAM="${1:-}"
  if [ -z "$SENDSTREAM" ] && [ "${1:-}" != "--cleanup" ]; then
      echo "Usage: $0 <sendstream> [size] [good_size_mb]" >&2
      echo "       $0 --cleanup" >&2
      exit 1
  fi

  LOOP_FILE="${LOOP_FILE:-/tmp/flakey-disk.img}"
  TOTAL_SIZE="${2:-1G}"
  GOOD_MB="${3:-200}"
  DM_NAME="flakey-combo"
  MNT="${MNT:-/tmp/flakey-mnt}"

  cleanup() {
      echo "Cleaning up..."
      umount "$MNT" 2>/dev/null || true
      dmsetup remove "$DM_NAME" 2>/dev/null || true
      if [ -f "$LOOP_FILE" ]; then
          local loop
          loop=$(losetup -j "$LOOP_FILE" 2>/dev/null | cut -d: -f1)
          [ -n "$loop" ] && losetup -d "$loop" 2>/dev/null || true
      fi
      rm -f "$LOOP_FILE"
      rmdir "$MNT" 2>/dev/null || true
      echo "Done."
  }

  if [ "${1:-}" = "--cleanup" ]; then
      cleanup
      exit 0
  fi

  [ "$(id -u)" -ne 0 ] && { echo "Must run as root" >&2; exit 1; }

  trap cleanup EXIT

  # Create backing file and loop device
  echo "Creating ${TOTAL_SIZE} backing file..."
  truncate -s "$TOTAL_SIZE" "$LOOP_FILE"
  LOOP=$(losetup --find --show "$LOOP_FILE")
  TOTAL_SECTORS=$(blockdev --getsz "$LOOP")
  GOOD_SECTORS=$(( GOOD_MB * 1024 * 1024 / 512 ))
  BAD_SECTORS=$(( TOTAL_SECTORS - GOOD_SECTORS ))

  echo "Loop device: $LOOP"
  echo "Total sectors: $TOTAL_SECTORS ($(( TOTAL_SECTORS * 512 / 1024 / 1024 ))MB)"
  echo "Good sectors: $GOOD_SECTORS (${GOOD_MB}MB)"
  echo "Bad sectors:  $BAD_SECTORS ($(( BAD_SECTORS * 512 / 1024 / 1024 ))MB)"

  # Format btrfs on the reliable device
  echo ""
  echo "Formatting btrfs on reliable device..."
  mkfs.btrfs -f "$LOOP"

  # Create dm device: first N MB linear (ok), rest flakey (error_writes)
  echo "Creating dm device (first ${GOOD_MB}MB ok, rest errors)..."
  dmsetup create "$DM_NAME" <<EOF
  0 $GOOD_SECTORS linear $LOOP 0
  $GOOD_SECTORS $BAD_SECTORS flakey $LOOP $GOOD_SECTORS 0 1 1 error_writes
  EOF

  echo "Device: /dev/mapper/$DM_NAME"
  mkdir -p "$MNT"
  mount "/dev/mapper/$DM_NAME" "$MNT"
  echo "Mounted at $MNT"
  echo ""
  echo "First ${GOOD_MB}MB: normal I/O"
  echo "After ${GOOD_MB}MB: all writes return -EIO"

  run_test() {
      local label="$1"
      shift
      echo ""
      echo "=== Test: $label ==="
      echo "Command: /root/btrfs receive $* -f $SENDSTREAM $MNT"
      # Clean mount between tests
      umount "$MNT" 2>/dev/null || true
      # Temporarily make device reliable for mkfs
      dmsetup suspend "$DM_NAME"
      dmsetup load "$DM_NAME" --table "0 $TOTAL_SECTORS linear $LOOP 0"
      dmsetup resume "$DM_NAME"
      mkfs.btrfs -f "/dev/mapper/$DM_NAME" >/dev/null 2>&1
      mount "/dev/mapper/$DM_NAME" "$MNT"
      # Switch back to flakey
      sync
      dmsetup suspend "$DM_NAME"
      dmsetup load "$DM_NAME" <<DMEOF
  0 $GOOD_SECTORS linear $LOOP 0
  $GOOD_SECTORS $BAD_SECTORS flakey $LOOP $GOOD_SECTORS 0 1 1 error_writes
  DMEOF
      dmsetup resume "$DM_NAME"
      /root/btrfs receive -v "$@" -f "$SENDSTREAM" "$MNT"
      echo "Exit code: $?"
      return 0
  }

  run_test "no sync flags"
  run_test "with --syncfs" --syncfs
  run_test "with --fsync" --fsync

  ./flakey.sh ./sendstream 2G 100
  Creating 2G backing file...
  Loop device: /dev/loop1
  Total sectors: 4194304 (2048MB)
  Good sectors: 204800 (100MB)
  Bad sectors:  3989504 (1948MB)

  Formatting btrfs on reliable device...
  btrfs-progs v6.7
  See https://btrfs.readthedocs.io for more information.

  Performing full device TRIM /dev/loop1 (2.00GiB) ...
  NOTE: several default settings have changed in version 5.15, please make sure
        this does not affect your deployments:
        - DUP for metadata (-m dup)
        - enabled no-holes (-O no-holes)
        - enabled free-space-tree (-R free-space-tree)

  Label:              (null)
  UUID:               5844132e-feb1-452e-8942-ca8b92321b62
  Node size:          16384
  Sector size:        4096
  Filesystem size:    2.00GiB
  Block group profiles:
    Data:             single            8.00MiB
    Metadata:         DUP             102.38MiB
    System:           DUP               8.00MiB
  SSD detected:       yes
  Zoned device:       no
  Incompat features:  extref, skinny-metadata, no-holes, free-space-tree
  Runtime features:   free-space-tree
  Checksum:           crc32c
  Number of devices:  1
  Devices:
     ID        SIZE  PATH
      1     2.00GiB  /dev/loop1

  Creating dm device (first 100MB ok, rest errors)...
  Device: /dev/mapper/flakey-combo
  Mounted at /tmp/flakey-mnt

  First 100MB: normal I/O
  After 100MB: all writes return -EIO

  === Test: no sync flags ===
  Command: /root/btrfs receive  -f ./sendstream /tmp/flakey-mnt
  At subvol volume
  ERROR: ioctl BTRFS_IOC_SET_RECEIVED_SUBVOL failed: Input/output error
  Exit code: 1

  === Test: with --syncfs ===
  Command: /root/btrfs receive --syncfs -f ./sendstream /tmp/flakey-mnt
  At subvol volume
  ERROR: ioctl BTRFS_IOC_SET_RECEIVED_SUBVOL failed: Input/output error
  ERROR: syncfs on destination failed: Input/output error
  Exit code: 1

  === Test: with --fsync ===
  Command: /root/btrfs receive --fsync -f ./sendstream /tmp/flakey-mnt
  At subvol volume
  ERROR: fsync on /tmp/flakey-mnt//volume/.meta/private/opts/artifacts_may_require_repo failed: Input/output error
  Exit code: 1
  Cleaning up...
  Done.