### PR TITLE
btrfs-progs: reject writes if the fs has running  replace/balance

### DIFF
--- a/Documentation/btrfs-check.rst
+++ b/Documentation/btrfs-check.rst
@@ -110,6 +110,9 @@ DANGEROUS OPTIONS
                 *--force* to give users a chance to think twice before running repair, the
                 warnings in documentation have shown to be insufficient.
 
+	.. note::
+		Please finish/cancel the running replace/balance before using this command.
+
 --init-csum-tree
         create a new checksum tree and recalculate checksums in all files
 

--- a/Documentation/btrfs-rescue.rst
+++ b/Documentation/btrfs-rescue.rst
@@ -12,6 +12,10 @@ DESCRIPTION
 A set of commands that are targeting to fix a specific problem and may not
 suitable for :doc`btrfs-check`.
 
+.. note::
+   All the subcommands can not handle an ongoing replace/balance, please finish/cancel
+   the replace/balance before using this command.
+
 SUBCOMMAND
 ----------
 

--- a/Documentation/btrfstune.rst
+++ b/Documentation/btrfstune.rst
@@ -21,6 +21,10 @@ complete list of features and kernel version of their introduction at
 Some of the features could be also enabled on a mounted filesystem by other
 means.  Please refer to the *FILESYSTEM FEATURES* in :doc:`btrfs-man5`.
 
+.. note::
+   :command:`btrfstune` requires the target fs to have no running replace nor balance.
+   Please finish/cancel the running replace/balance before using :command:`btrfstune`.
+
 OPTIONS
 -------
 

--- a/check/main.c
+++ b/check/main.c
@@ -10825,6 +10825,19 @@ static int cmd_check(const struct cmd_struct *cmd, int argc, char **argv)
 		err |= !!ret;
 		goto err_out;
 	}
+	if (opt_check_repair) {
+		ret = has_running_replace_or_balance(gfs_info);
+		if (ret < 0) {
+			err |= !!ret;
+			goto close_out;
+		}
+		if (ret > 0) {
+			error("please finish/cacnel the running replace/balance before running this command");
+			ret = -EINVAL;
+			err |= !!ret;
+			goto close_out;
+		}
+	}
 
 	root = gfs_info->fs_root;
 	uuid_unparse(gfs_info->super_copy->fsid, uuidbuf);

--- a/cmds/rescue-fix-data-checksum.c
+++ b/cmds/rescue-fix-data-checksum.c
@@ -24,6 +24,7 @@
 #include "kernel-shared/file-item.h"
 #include "common/messages.h"
 #include "common/open-utils.h"
+#include "common/clear-cache.h"
 #include "cmds/rescue.h"
 
 /*
@@ -491,6 +492,14 @@ int btrfs_recover_fix_data_checksum(const char *path, enum btrfs_fix_data_checks
 	if (!fs_info) {
 		error("failed to open btrfs at %s", path);
 		return -EIO;
+	}
+	ret = has_running_replace_or_balance(fs_info);
+	if (ret < 0)
+		goto out_close;
+	if (ret > 0) {
+		error("please finish/cancel the running replace/balance before running this command");
+		ret = -EINVAL;
+		goto out_close;
 	}
 	csum_root = btrfs_csum_root(fs_info, 0);
 	if (!csum_root) {

--- a/cmds/rescue.c
+++ b/cmds/rescue.c
@@ -466,7 +466,17 @@ static int cmd_rescue_clear_uuid_tree(const struct cmd_struct *cmd,
 		goto out;
 	}
 
+	ret = has_running_replace_or_balance(fs_info);
+	if (ret < 0)
+		goto out_close;
+	if (ret > 0) {
+		error("please finish/cancel the running replace/balance before running this command");
+		ret = -EINVAL;
+		goto out_close;
+	}
+
 	ret = clear_uuid_tree(fs_info);
+out_close:
 	close_ctree(fs_info->tree_root);
 out:
 	return !!ret;
@@ -511,6 +521,14 @@ static int cmd_rescue_clear_ino_cache(const struct cmd_struct *cmd,
 		ret = -EIO;
 		goto out;
 	}
+	ret = has_running_replace_or_balance(fs_info);
+	if (ret < 0)
+		goto out_close;
+	if (ret > 0) {
+		error("please finish/cancel the running replace/balance before running this command");
+		ret = -EINVAL;
+		goto out_close;
+	}
 	ret = clear_ino_cache_items(fs_info);
 	if (ret < 0) {
 		errno = -ret;
@@ -518,6 +536,7 @@ static int cmd_rescue_clear_ino_cache(const struct cmd_struct *cmd,
 	} else {
 		pr_default("Successfully cleared ino cache\n");
 	}
+out_close:
 	close_ctree(fs_info->tree_root);
 out:
 	return !!ret;

--- a/common/clear-cache.c
+++ b/common/clear-cache.c
@@ -98,10 +98,67 @@ int btrfs_clear_v1_cache(struct btrfs_fs_info *fs_info)
 	return ret;
 }
 
+/*
+ * Return <0 for critical errors, mostly tree search failure.
+ * Return >0 if there is a running balance or replace.
+ * Return 0 if there is no running balance nor replace.
+ */
+int has_running_replace_or_balance(struct btrfs_fs_info *fs_info)
+{
+	struct btrfs_root *tree_root = fs_info->tree_root;
+	struct btrfs_root *dev_root = fs_info->dev_root;
+	struct btrfs_path path = { 0 };
+	struct btrfs_key key;
+	struct btrfs_dev_replace_item *dri;
+	u64 replace_state;
+	int ret;
+
+	key.objectid = BTRFS_BALANCE_OBJECTID;
+	key.type = BTRFS_TEMPORARY_ITEM_KEY;
+	key.offset = 0;
+
+	ret = btrfs_search_slot(NULL, tree_root, &key, &path, 0, 0);
+	btrfs_release_path(&path);
+	if (ret < 0)
+		return ret;
+	if (ret == 0)
+		return 1;
+
+	key.objectid = 0;
+	key.type = BTRFS_DEV_REPLACE_KEY;
+	key.offset = 0;
+
+	ret = btrfs_search_slot(NULL, dev_root, &key, &path, 0, 0);
+	if (ret < 0)
+		return ret;
+	if (ret > 0) {
+		btrfs_release_path(&path);
+		return 0;
+	}
+	/*
+	 * We still need to check if the dev_replace item to determine if
+	 * there is a running replace.
+	 */
+	dri = btrfs_item_ptr(path.nodes[0], path.slots[0], struct btrfs_dev_replace_item);
+	replace_state = btrfs_dev_replace_replace_state(path.nodes[0], dri);
+	btrfs_release_path(&path);
+	if (replace_state == BTRFS_IOCTL_DEV_REPLACE_STATE_STARTED ||
+	    replace_state == BTRFS_IOCTL_DEV_REPLACE_STATE_SUSPENDED)
+		return 1;
+	return 0;
+}
+
 int do_clear_free_space_cache(struct btrfs_fs_info *fs_info, int clear_version)
 {
 	int ret = 0;
 
+	ret = has_running_replace_or_balance(fs_info);
+	if (ret < 0)
+		return ret;
+	if (ret > 0) {
+		error("please finish/cancel the running replace/balance before running this command");
+		return -EINVAL;
+	}
 	if (clear_version == 1) {
 		if (btrfs_fs_compat_ro(fs_info, FREE_SPACE_TREE))
 			warning(

--- a/common/clear-cache.h
+++ b/common/clear-cache.h
@@ -26,5 +26,6 @@ int do_clear_free_space_cache(struct btrfs_fs_info *fs_info, int clear_version);
 int validate_free_space_cache(struct btrfs_root *root, struct task_ctx *task_ctx);
 int truncate_free_ino_items(struct btrfs_root *root);
 int clear_ino_cache_items(struct btrfs_fs_info *fs_info);
+int has_running_replace_or_balance(struct btrfs_fs_info *fs_info);
 
 #endif

--- a/tune/main.c
+++ b/tune/main.c
@@ -415,6 +415,16 @@ int BOX_MAIN(btrfstune)(int argc, char *argv[])
 	}
 	fs_info = root->fs_info;
 
+	ret = has_running_replace_or_balance(fs_info);
+	if (ret < 0) {
+		ret = 1;
+		goto out;
+	}
+	if (ret > 0) {
+		error("please finish/cancel the running replace/balance before running this command");
+		ret = 1;
+		goto out;
+	}
 	/*
 	 * As we increment the generation number here, it is unlikely that the
 	 * missing device will have a higher generation number, and the kernel


### PR DESCRIPTION
Btrfs-progs never has the ability to handle reloc trees, thus if a btrfs
with running balance is passed to btrfstune, btrfstune will just ignore
all the reloc trees and continue modifying the fs.

This can easily screw up the balance resume on the next RW mount and
corrupt the fs.

For dev-replace it's very similar, we can modify the metadata before the
current replace cursor, causing writes that will not be written to the
dev-replace target device and cause corruption.

Reject those fses with running replace/balance to prevent corruption for
the following tools:

- btrfstune
  All write operations will be rejected.

- btrfs check --clear-space-cache
- btrfs rescue clear-space-cache
- btrfs rescue fix-data-checksum
- btrfs rescue clear-uuid-tree
- btrfs rescue clear-ino-cache
- btrfs check --repair

Some "btrfs rescue" subcommands do not start a new transaction and
directly update the super blocks, thus they are safe from the
replace/balance.