### PR TITLE
Add CRC32C SSE4.2 tests to hash-speed/-vectest

### DIFF
--- a/crypto/hash-speedtest.c
+++ b/crypto/hash-speedtest.c
@@ -188,6 +188,8 @@ int main(int argc, char **argv) {
 		{ .name = "NULL-MEMCPY", .digest = hash_null_memcpy, .digest_size = 32 },
 		{ .name = "CRC32C-ref", .digest = hash_crc32c, .digest_size = 4,
 		  .cpu_flag = CPU_FLAG_NONE },
+		{ .name = "CRC32C-SSE42", .digest = hash_crc32c, .digest_size = 4,
+		  .cpu_flag = CPU_FLAG_SSE42 },
 		{ .name = "CRC32C-NI", .digest = hash_crc32c, .digest_size = 4,
 		  .cpu_flag = CPU_FLAG_PCLMUL },
 		{ .name = "XXHASH", .digest = hash_xxhash, .digest_size = 8 },

--- a/crypto/hash-vectest.c
+++ b/crypto/hash-vectest.c
@@ -435,6 +435,13 @@ static const struct hash_testspec test_spec[] = {
 		.cpu_flag = CPU_FLAG_NONE,
 		.hash = hash_crc32c,
 	}, {
+		.name = "CRC32C-SSE42",
+		.digest_size = 4,
+		.testvec = crc32c_tv,
+		.count = ARRAY_SIZE(crc32c_tv),
+		.cpu_flag = CPU_FLAG_SSE42,
+		.hash = hash_crc32c,
+	}, {
 		.name = "CRC32C-NI",
 		.digest_size = 4,
 		.testvec = crc32c_tv,


### PR DESCRIPTION
The `hash-speedtest` and `hash-vectest` tests are missing the relevant CRC32C SSE4.2 rounds.

It's useful to see what the difference in speed between CRC32C and the other algorithms are on a CPU which supports SSE4.2 but not for example PCLMUL.