### PR TITLE
include/kerncompat.h: add fallback for static_assert

### DIFF
--- a/include/kerncompat.h
+++ b/include/kerncompat.h
@@ -31,6 +31,10 @@
 #include <endian.h>
 #include <byteswap.h>
 #include <assert.h>
+
+#ifndef static_assert
+#define static_assert(expr, str) _Static_assert(expr, str)
+#endif
 #include <stddef.h>
 #include <linux/types.h>
 #include <linux/const.h>


### PR DESCRIPTION
The build fails for some uClibc toolchains with:
undefined reference to 'static_assert'

This happens because some toolchains do not define the 'static_assert'
macro in <assert.h> even when compiling with -std=gnu11. btrfs-progs
uses static_assert in the container_of macro in include/kerncompat.h.

Fix this by providing a fallback definition using _Static_assert.