### PR TITLE
btrfs-progs: fix the overly strict chunk type check on dump-tree

### DIFF
--- a/cmds/inspect-dump-tree.c
+++ b/cmds/inspect-dump-tree.c
@@ -206,8 +206,9 @@ static int check_metadata_logical(struct btrfs_fs_info *fs_info, u64 logical)
 		return -ENOENT;
 	}
 	map = container_of(ce, struct map_lookup, ce);
-	if (!(map->type & BTRFS_BLOCK_GROUP_METADATA)) {
-		error("logical %llu is not in a metadata chunk, found chunk %llu len %llu flags 0x%llx",
+	if (!(map->type & (BTRFS_BLOCK_GROUP_METADATA |
+			   BTRFS_BLOCK_GROUP_SYSTEM))) {
+		error("logical %llu is not in a metadata/system chunk, found chunk %llu len %llu flags 0x%llx",
 		      logical, ce->start, ce->size, map->type);
 		return -EINVAL;
 	}

--- a/tests/misc-tests/072-dump-tree-chunk-bytenr/test.sh
+++ b/tests/misc-tests/072-dump-tree-chunk-bytenr/test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Test "btrfs ins dump-tree -b <bytenr>" when the bytenr belongs to a chunk
+# tree block.
+#
+# This is a regression test for commit 408e45feb325 ("btrfs-progs:
+# dump-tree: add extra chunk type checks"), which is too strict and
+# rejects chunk tree blocks.
+
+source "$TEST_TOP/common" || exit
+source "$TEST_TOP/common.convert" || exit
+
+check_prereq mkfs.btrfs
+check_prereq btrfs
+
+setup_root_helper
+prepare_test_dev
+
+run_check_mkfs_test_dev
+chunk_root=$(run_check_stdout "$TOP/btrfs" inspect-internal dump-tree -t chunk "$TEST_DEV" |\
+	     grep "owner CHUNK_TREE" | cut -f 2 -d\ )
+if [ -z "$chunk_root" ]; then
+	_fail "unable to get the chunk root bytenr"
+fi
+
+run_check "$TOP/btrfs" inspect-internal dump-tree -b "$chunk_root" "$TEST_DEV"


### PR DESCRIPTION
Commit 408e45feb325 ("btrfs-progs: dump-tree: add extra chunk type
checks") introduced a chunk type check before dumping the tree.

However it's too strict as I'm a total idiot, and forgot to we still
need to dump chunk tree blocks.

Fix it and add a regression test.