### PR TITLE
mkfs.btrfs: support reproducible image creation

### DIFF
--- a/Documentation/mkfs.btrfs.rst
+++ b/Documentation/mkfs.btrfs.rst
@@ -708,6 +708,48 @@ by large metadata blocks and space reservation strategy that allocates more
 than can fit into the filesystem.
 
 
+ENVIRONMENT
+-----------
+
+:command:`mkfs.btrfs` honors two environment variables that make image
+creation reproducible, so that the same inputs produce a byte-for-byte
+identical image.
+
+SOURCE_DATE_EPOCH
+        A decimal count of seconds since the Unix epoch
+        (`reproducible-builds.org <https://reproducible-builds.org>`_),
+        used in place of the current time for the timestamps written into
+        the image: the root-item and inode times of the created trees.
+        With *--rootdir*, each copied file's *ctime* and *atime* are set to
+        this value. Its *mtime* is taken from the source but clamped to it,
+        so nothing in the image is newer than the source date.
+
+        An empty value is treated as unset. A value that is not a
+        non-negative integer fitting in the platform time type is a hard
+        error.
+
+DETERMINISTIC_SEED
+        When set to *1*, the internal UUIDs that are otherwise random (the
+        chunk-tree UUID, each device UUID and each subvolume UUID) are
+        instead derived deterministically from the filesystem UUID. A fixed
+        filesystem UUID must be supplied with *-U*; without it
+        :command:`mkfs.btrfs` exits with an error rather than emit a random
+        image. Any value other than *1* leaves UUID generation random.
+
+To create a reproducible image, pin the filesystem UUID with *-U*, set
+``SOURCE_DATE_EPOCH`` and ``DETERMINISTIC_SEED``, normalize source ownership,
+and start with a fresh target file. :command:`mkfs.btrfs` copies *uid* and
+*gid* from the source tree and, like other mkfs tools, does not zero space it
+does not write:
+
+.. code-block:: bash
+
+        $ chown -R 0:0 ./rootdir
+        $ truncate -s 1G image.btrfs
+        $ SOURCE_DATE_EPOCH=1700000000 DETERMINISTIC_SEED=1 \
+                mkfs.btrfs -U <uuid> --rootdir ./rootdir image.btrfs
+
+
 AVAILABILITY
 ------------
 

--- a/Makefile
+++ b/Makefile
@@ -233,6 +233,7 @@ objects = \
 	common/parse-utils.o	\
 	common/path-utils.o	\
 	common/rbtree-utils.o	\
+	common/reproducible.o	\
 	common/send-stream.o	\
 	common/send-utils.o	\
 	common/sort-utils.o	\

--- a/common/device-scan.c
+++ b/common/device-scan.c
@@ -48,6 +48,7 @@
 #include "common/path-utils.h"
 #include "common/device-scan.h"
 #include "common/messages.h"
+#include "common/reproducible.h"
 #include "common/utils.h"
 #include "common/defs.h"
 #include "common/open-utils.h"
@@ -155,7 +156,10 @@ int btrfs_add_to_fsid(struct btrfs_trans_handle *trans,
 	disk_super = (struct btrfs_super_block *)buf;
 	dev_item = &disk_super->dev_item;
 
-	uuid_generate(device->uuid);
+	reproducible_uuid_generate(super->fsid,
+				   REPRODUCIBLE_UUID_ROLE_DEVICE,
+				   btrfs_super_num_devices(super) + 1,
+				   device->uuid);
 	device->fs_info = fs_info;
 	device->devid = 0;
 	device->type = 0;

--- a/common/path-utils.c
+++ b/common/path-utils.c
@@ -20,7 +20,9 @@
 #include <linux/kdev_t.h>
 #include <linux/loop.h>
 #include <linux/limits.h>
+#include <dirent.h>
 #include <fcntl.h>
+#include <ftw.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -507,4 +509,142 @@ int path_readlink(char *dest, const char *src)
 		return -ENAMETOOLONG;
 	dest[ret] = 0;
 	return ret;
+}
+
+struct path_walk_entry {
+	char *name;
+};
+
+static int path_walk_entry_cmp(const void *a, const void *b)
+{
+	const struct path_walk_entry *ea = a;
+	const struct path_walk_entry *eb = b;
+
+	return strcmp(ea->name, eb->name);
+}
+
+/*
+ * Emulate nftw()'s depth-first, preorder, FTW_PHYS walk, but visit each
+ * directory's entries in sorted name order. The struct FTW fields are filled
+ * the way nftw() reports them so existing nftw() callbacks work unchanged.
+ */
+static int path_sorted_walk_recursive(char *path, int level, path_walk_cb cb)
+{
+	struct stat st;
+	struct FTW ftwbuf;
+	struct path_walk_entry *entries = NULL;
+	size_t count = 0, cap = 0;
+	DIR *dir = NULL;
+	struct dirent *de;
+	const char *slash;
+	int ret;
+
+	slash = strrchr(path, '/');
+	ftwbuf.base = slash ? (int)(slash - path + 1) : 0;
+	ftwbuf.level = level;
+
+	if (lstat(path, &st) != 0)
+		return cb(path, NULL, FTW_NS, &ftwbuf);
+
+	if (!S_ISDIR(st.st_mode)) {
+		if (S_ISLNK(st.st_mode))
+			return cb(path, &st, FTW_SL, &ftwbuf);
+		return cb(path, &st, FTW_F, &ftwbuf);
+	}
+
+	/*
+	 * Open the directory before reporting it: one we can lstat() but not
+	 * open is reported once as FTW_DNR, not FTW_D then FTW_DNR.
+	 */
+	dir = opendir(path);
+	if (!dir)
+		return cb(path, &st, FTW_DNR, &ftwbuf);
+
+	ret = cb(path, &st, FTW_D, &ftwbuf);
+	if (ret)
+		goto cleanup;
+
+	/*
+	 * readdir() returns NULL at both end-of-stream and error; clear
+	 * errno before each call to tell them apart after the loop.
+	 */
+	while (1) {
+		errno = 0;
+		de = readdir(dir);
+		if (!de)
+			break;
+		if (strcmp(de->d_name, ".") == 0 ||
+		    strcmp(de->d_name, "..") == 0)
+			continue;
+		if (count == cap) {
+			struct path_walk_entry *new_entries;
+
+			cap = cap ? cap * 2 : 16;
+			new_entries = reallocarray(entries, cap,
+						   sizeof(*entries));
+			if (!new_entries) {
+				ret = -ENOMEM;
+				goto cleanup;
+			}
+			entries = new_entries;
+		}
+		entries[count].name = strndup(de->d_name, NAME_MAX);
+		if (!entries[count].name) {
+			ret = -ENOMEM;
+			goto cleanup;
+		}
+		count++;
+	}
+	if (errno != 0) {
+		ret = -errno;
+		goto cleanup;
+	}
+	closedir(dir);
+	dir = NULL;
+
+	if (count)
+		qsort(entries, count, sizeof(*entries), path_walk_entry_cmp);
+
+	for (size_t i = 0; i < count; i++) {
+		char *child = malloc(PATH_MAX);
+
+		if (!child) {
+			ret = -ENOMEM;
+			goto cleanup;
+		}
+		ret = path_cat_out(child, path, entries[i].name);
+		if (!ret)
+			ret = path_sorted_walk_recursive(child, level + 1, cb);
+		free(child);
+		if (ret)
+			goto cleanup;
+	}
+	ret = 0;
+
+cleanup:
+	if (dir)
+		closedir(dir);
+	for (size_t i = 0; i < count; i++)
+		free(entries[i].name);
+	free(entries);
+	return ret;
+}
+
+int path_sorted_walk(const char *root, path_walk_cb cb)
+{
+	char path[PATH_MAX];
+	size_t root_len = strlen(root);
+
+	/* glibc nftw() rejects an empty path with ENOENT and no callback. */
+	if (root_len == 0)
+		return -ENOENT;
+	if (root_len >= sizeof(path))
+		return -ENAMETOOLONG;
+	memcpy(path, root, root_len + 1);
+
+	/* Strip trailing slashes (but keep a lone "/"), matching nftw. */
+	while (root_len > 1 && path[root_len - 1] == '/')
+		path[--root_len] = '\0';
+
+	return path_sorted_walk_recursive(path, 0, cb);
 }

--- a/common/path-utils.h
+++ b/common/path-utils.h
@@ -18,7 +18,9 @@
 #define __BTRFS_PATH_UTILS_H__
 
 #include <sys/types.h>
+#include <sys/stat.h>
 #include <linux/limits.h>
+#include <ftw.h>
 
 char *path_canonicalize_dm_name(const char *ptname);
 char *path_canonicalize(const char *path);
@@ -37,5 +39,31 @@ int path_is_in_dir(const char *parent, const char *path);
 char *path_basename(char *path);
 char *path_dirname(char *path);
 int path_readlink(char *dest, const char *src);
+
+/*
+ * Callback for path_sorted_walk(), matching nftw()'s callback signature
+ * so existing nftw() callbacks can be reused unchanged.
+ *
+ *   st     : lstat() result, or NULL when type == FTW_NS
+ *   type   : FTW_F, FTW_D (pre-order), FTW_SL (never followed),
+ *            FTW_DNR (unreadable directory) or FTW_NS (lstat failed)
+ *   ftwbuf : level (depth, 0 at the root) and base (basename offset)
+ *
+ * Return 0 to continue the walk, non-zero to abort it (that value is
+ * then returned by path_sorted_walk()).
+ */
+typedef int (*path_walk_cb)(const char *path, const struct stat *st,
+			    int type, struct FTW *ftwbuf);
+
+/*
+ * Walk a directory tree depth-first, pre-order, visiting the entries of
+ * each directory in byte-wise (strcmp) name order. Symlinks are never
+ * followed (FTW_PHYS). Sorting makes the walk order independent of the
+ * filesystem's readdir() order.
+ *
+ * Returns 0 on success, the callback's non-zero return value if it
+ * aborted, or -errno on I/O failure.
+ */
+int path_sorted_walk(const char *root, path_walk_cb cb);
 
 #endif

--- a/common/reproducible.c
+++ b/common/reproducible.c
@@ -40,6 +40,13 @@ time_t reproducible_now(void)
 	return (time_t)val;
 }
 
+bool reproducible_has_source_date(void)
+{
+	const char *sde = getenv("SOURCE_DATE_EPOCH");
+
+	return sde && *sde;
+}
+
 bool reproducible_is_deterministic(void)
 {
 	const char *v = getenv("DETERMINISTIC_SEED");

--- a/common/reproducible.c
+++ b/common/reproducible.c
@@ -54,6 +54,11 @@ bool reproducible_is_deterministic(void)
 	return v && strcmp(v, "1") == 0;
 }
 
+bool reproducible_is_enabled(void)
+{
+	return reproducible_has_source_date() && reproducible_is_deterministic();
+}
+
 void reproducible_uuid_generate(const u8 fs_uuid[BTRFS_UUID_SIZE],
 				enum reproducible_uuid_role role, u64 key,
 				u8 out[BTRFS_UUID_SIZE])

--- a/common/reproducible.c
+++ b/common/reproducible.c
@@ -17,7 +17,9 @@
 #include "kerncompat.h"
 #include <limits.h>
 #include <stdlib.h>
+#include <string.h>
 #include <time.h>
+#include <uuid/uuid.h>
 #include "common/messages.h"
 #include "common/parse-utils.h"
 #include "common/reproducible.h"
@@ -36,4 +38,27 @@ time_t reproducible_now(void)
 		exit(1);
 	}
 	return (time_t)val;
+}
+
+bool reproducible_is_deterministic(void)
+{
+	const char *v = getenv("DETERMINISTIC_SEED");
+
+	return v && strcmp(v, "1") == 0;
+}
+
+void reproducible_uuid_generate(const u8 fs_uuid[BTRFS_UUID_SIZE],
+				enum reproducible_uuid_role role, u64 key,
+				u8 out[BTRFS_UUID_SIZE])
+{
+	u8 name[sizeof(u32) + sizeof(u64)];
+
+	if (!reproducible_is_deterministic()) {
+		uuid_generate(out);
+		return;
+	}
+
+	put_unaligned_le32((u32)role, name);
+	put_unaligned_le64(key, name + sizeof(u32));
+	uuid_generate_sha1(out, fs_uuid, (const char *)name, sizeof(name));
 }

--- a/common/reproducible.c
+++ b/common/reproducible.c
@@ -1,0 +1,39 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License v2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 021110-1307, USA.
+ */
+
+#include "kerncompat.h"
+#include <limits.h>
+#include <stdlib.h>
+#include <time.h>
+#include "common/messages.h"
+#include "common/parse-utils.h"
+#include "common/reproducible.h"
+
+time_t reproducible_now(void)
+{
+	const char *sde = getenv("SOURCE_DATE_EPOCH");
+	u64 val;
+
+	if (!sde || !*sde)
+		return time(NULL);
+
+	if (parse_u64(sde, &val) < 0 || val > (u64)LONG_MAX) {
+		error("invalid SOURCE_DATE_EPOCH: '%s' is not a non-negative integer fitting in time_t",
+		      sde);
+		exit(1);
+	}
+	return (time_t)val;
+}

--- a/common/reproducible.h
+++ b/common/reproducible.h
@@ -29,6 +29,8 @@
  */
 time_t reproducible_now(void);
 
+bool reproducible_has_source_date(void);
+
 bool reproducible_is_deterministic(void);
 
 enum reproducible_uuid_role {

--- a/common/reproducible.h
+++ b/common/reproducible.h
@@ -1,0 +1,29 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License v2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 021110-1307, USA.
+ */
+
+#ifndef __BTRFS_REPRODUCIBLE_H__
+#define __BTRFS_REPRODUCIBLE_H__
+
+#include <time.h>
+
+/*
+ * Return SOURCE_DATE_EPOCH as a time_t, or time(NULL) when it is unset
+ * or empty. Errors out if it is set to something other than a
+ * non-negative integer that fits in time_t.
+ */
+time_t reproducible_now(void);
+
+#endif

--- a/common/reproducible.h
+++ b/common/reproducible.h
@@ -17,7 +17,10 @@
 #ifndef __BTRFS_REPRODUCIBLE_H__
 #define __BTRFS_REPRODUCIBLE_H__
 
+#include "kerncompat.h"
+#include <stdbool.h>
 #include <time.h>
+#include "kernel-shared/uapi/btrfs.h"
 
 /*
  * Return SOURCE_DATE_EPOCH as a time_t, or time(NULL) when it is unset
@@ -25,5 +28,22 @@
  * non-negative integer that fits in time_t.
  */
 time_t reproducible_now(void);
+
+bool reproducible_is_deterministic(void);
+
+enum reproducible_uuid_role {
+	REPRODUCIBLE_UUID_ROLE_CHUNK_TREE,	/* singleton, key ignored */
+	REPRODUCIBLE_UUID_ROLE_SUBVOL,		/* key = subvolume objectid */
+	REPRODUCIBLE_UUID_ROLE_DEVICE,		/* key = devid */
+};
+
+/*
+ * Fill out with a 16-byte UUID. In deterministic mode (DETERMINISTIC_SEED
+ * set) it is derived from the fs UUID and the (role, key) pair, so it is
+ * reproducible but distinct per pair; otherwise it is random.
+ */
+void reproducible_uuid_generate(const u8 fs_uuid[BTRFS_UUID_SIZE],
+				enum reproducible_uuid_role role, u64 key,
+				u8 out[BTRFS_UUID_SIZE]);
 
 #endif

--- a/common/reproducible.h
+++ b/common/reproducible.h
@@ -33,6 +33,9 @@ bool reproducible_has_source_date(void);
 
 bool reproducible_is_deterministic(void);
 
+/* True when SOURCE_DATE_EPOCH is non-empty and DETERMINISTIC_SEED is "1". */
+bool reproducible_is_enabled(void);
+
 enum reproducible_uuid_role {
 	REPRODUCIBLE_UUID_ROLE_CHUNK_TREE,	/* singleton, key ignored */
 	REPRODUCIBLE_UUID_ROLE_SUBVOL,		/* key = subvolume objectid */

--- a/common/root-tree-utils.c
+++ b/common/root-tree-utils.c
@@ -20,15 +20,16 @@
 #include "kernel-shared/disk-io.h"
 #include "kernel-shared/uuid-tree.h"
 #include "kernel-shared/transaction.h"
-#include "common/root-tree-utils.h"
 #include "common/messages.h"
+#include "common/reproducible.h"
+#include "common/root-tree-utils.h"
 
 int btrfs_make_root_dir(struct btrfs_trans_handle *trans,
 			struct btrfs_root *root, u64 objectid)
 {
 	int ret;
 	struct btrfs_inode_item inode_item;
-	time_t now = time(NULL);
+	time_t now = reproducible_now();
 
 	memset(&inode_item, 0, sizeof(inode_item));
 	btrfs_set_stack_inode_generation(&inode_item, trans->transid);

--- a/common/root-tree-utils.c
+++ b/common/root-tree-utils.c
@@ -284,7 +284,10 @@ static int rescan_subvol_uuid(struct btrfs_trans_handle *trans,
 	}
 	/* The uuid is not set, regenerate one. */
 	if (uuid_is_null(subvol->root_item.uuid)) {
-		uuid_generate(subvol->root_item.uuid);
+		reproducible_uuid_generate(fs_info->super_copy->fsid,
+					   REPRODUCIBLE_UUID_ROLE_SUBVOL,
+					   subvol_key->objectid,
+					   subvol->root_item.uuid);
 		ret = btrfs_update_root(trans, fs_info->tree_root, &subvol->root_key,
 					&subvol->root_item);
 		if (ret < 0) {

--- a/configure.ac
+++ b/configure.ac
@@ -452,7 +452,9 @@ dnl execution with error. The static libs are optional.
 PKG_CHECK_MODULES(BLKID, [blkid])
 PKG_STATIC(BLKID_LIBS_STATIC, [blkid])
 
-PKG_CHECK_MODULES(UUID, [uuid])
+dnl uuid >= 2.31 (util-linux, 2017) for uuid_generate_sha1(), used to
+dnl derive deterministic UUIDs for reproducible image creation.
+PKG_CHECK_MODULES(UUID, [uuid >= 2.31])
 PKG_STATIC(UUID_LIBS_STATIC, [uuid])
 
 PKG_CHECK_MODULES(ZLIB, [zlib])

--- a/mkfs/common.c
+++ b/mkfs/common.c
@@ -36,6 +36,7 @@
 #include "common/messages.h"
 #include "common/device-utils.h"
 #include "common/open-utils.h"
+#include "common/reproducible.h"
 #include "common/string-utils.h"
 #include "mkfs/common.h"
 
@@ -121,7 +122,7 @@ static int btrfs_create_tree_root(int fd, struct btrfs_mkfs_config *cfg,
 		btrfs_set_item_offset(buf, nritems, itemoff);
 		btrfs_set_item_size(buf, nritems, sizeof(root_item));
 		if (blk == MKFS_FS_TREE) {
-			time_t now = time(NULL);
+			time_t now = reproducible_now();
 
 			uuid_generate(uuid);
 			memcpy(root_item.uuid, uuid, BTRFS_UUID_SIZE);

--- a/mkfs/common.c
+++ b/mkfs/common.c
@@ -123,8 +123,12 @@ static int btrfs_create_tree_root(int fd, struct btrfs_mkfs_config *cfg,
 		btrfs_set_item_size(buf, nritems, sizeof(root_item));
 		if (blk == MKFS_FS_TREE) {
 			time_t now = reproducible_now();
+			u8 fs_uuid_bin[BTRFS_UUID_SIZE];
 
-			uuid_generate(uuid);
+			uuid_parse(cfg->fs_uuid, fs_uuid_bin);
+			reproducible_uuid_generate(fs_uuid_bin,
+				REPRODUCIBLE_UUID_ROLE_SUBVOL,
+				BTRFS_FS_TREE_OBJECTID, uuid);
 			memcpy(root_item.uuid, uuid, BTRFS_UUID_SIZE);
 			btrfs_set_stack_timespec_sec(&root_item.otime, now);
 			btrfs_set_stack_timespec_sec(&root_item.ctime, now);
@@ -460,12 +464,15 @@ int make_btrfs(int fd, struct btrfs_mkfs_config *cfg)
 		uuid_parse(cfg->fs_uuid, super.fsid);
 	}
 	if (!*cfg->dev_uuid) {
-		uuid_generate(super.dev_item.uuid);
+		reproducible_uuid_generate(super.fsid, REPRODUCIBLE_UUID_ROLE_DEVICE,
+					   1, super.dev_item.uuid);
 		uuid_unparse(super.dev_item.uuid, cfg->dev_uuid);
 	} else {
 		uuid_parse(cfg->dev_uuid, super.dev_item.uuid);
 	}
-	uuid_generate(chunk_tree_uuid);
+	reproducible_uuid_generate(super.fsid,
+				   REPRODUCIBLE_UUID_ROLE_CHUNK_TREE, 0,
+				   chunk_tree_uuid);
 
 	for (i = 0; i < blocks_nr; i++) {
 		blk = blocks[i];

--- a/mkfs/main.c
+++ b/mkfs/main.c
@@ -59,6 +59,7 @@
 #include "common/units.h"
 #include "common/string-utils.h"
 #include "common/string-table.h"
+#include "common/reproducible.h"
 #include "common/root-tree-utils.h"
 #include "cmds/commands.h"
 #include "check/qgroup-verify.h"
@@ -1868,6 +1869,10 @@ int BOX_MAIN(mkfs)(int argc, char **argv)
 			ret = 1;
 			goto error;
 		}
+	} else if (reproducible_is_deterministic()) {
+		error("DETERMINISTIC_SEED=1 requires -U/--uuid to be specified");
+		ret = 1;
+		goto error;
 	}
 
 	if (*dev_uuid) {

--- a/mkfs/main.c
+++ b/mkfs/main.c
@@ -1543,7 +1543,7 @@ int BOX_MAIN(mkfs)(int argc, char **argv)
 	u64 dev_byte_count = 0;
 	bool mixed = false;
 	char *label = NULL;
-	int nr_global_roots = sysconf(_SC_NPROCESSORS_ONLN);
+	int nr_global_roots = 1;
 	char *source_dir = NULL;
 	struct rootdir_subvol *rds;
 	struct rootdir_inode_flags_entry *rif;
@@ -2049,9 +2049,7 @@ int BOX_MAIN(mkfs)(int argc, char **argv)
 		goto error;
 	}
 
-	/* This is also fixed in kernel, but the flag has no real meaning anymore. */
-	if (nodesize > sysconf(_SC_PAGE_SIZE))
-		features.incompat_flags |= BTRFS_FEATURE_INCOMPAT_BIG_METADATA;
+	features.incompat_flags |= BTRFS_FEATURE_INCOMPAT_BIG_METADATA;
 
 	min_dev_size = btrfs_min_dev_size(nodesize, mixed,
 					  opt_zoned ? zone_size(file) : 0,

--- a/mkfs/rootdir.c
+++ b/mkfs/rootdir.c
@@ -310,6 +310,11 @@ static void stat_to_inode_item(struct btrfs_inode_item *dst, const struct stat *
 	btrfs_set_stack_timespec_nsec(&dst->otime, 0);
 }
 
+static int xattr_name_cmp(const void *a, const void *b)
+{
+	return strcmp(*(const char * const *)a, *(const char * const *)b);
+}
+
 static int add_xattr_item(struct btrfs_trans_handle *trans,
 			  struct btrfs_root *root, u64 objectid,
 			  const char *file_name)
@@ -320,6 +325,9 @@ static int add_xattr_item(struct btrfs_trans_handle *trans,
 	char *xattr_list_end;
 	char *cur_name;
 	char cur_value[XATTR_SIZE_MAX];
+	char **names = NULL;
+	size_t nr_names = 0;
+	size_t i;
 
 	ret = llistxattr(file_name, xattr_list, XATTR_LIST_MAX);
 	if (ret < 0) {
@@ -332,17 +340,37 @@ static int add_xattr_item(struct btrfs_trans_handle *trans,
 		return ret;
 
 	xattr_list_end = xattr_list + ret;
-	cur_name = xattr_list;
-	while (cur_name < xattr_list_end) {
+
+	for (cur_name = xattr_list; cur_name < xattr_list_end;
+	     cur_name += strlen(cur_name) + 1)
+		nr_names++;
+
+	names = malloc(nr_names * sizeof(*names));
+	if (!names) {
+		error("not enough memory to process xattrs of %s", file_name);
+		return -ENOMEM;
+	}
+	i = 0;
+	for (cur_name = xattr_list; cur_name < xattr_list_end;
+	     cur_name += strlen(cur_name) + 1)
+		names[i++] = cur_name;
+
+	/* llistxattr() order is filesystem-defined. */
+	if (reproducible_is_enabled())
+		qsort(names, nr_names, sizeof(*names), xattr_name_cmp);
+
+	for (i = 0; i < nr_names; i++) {
+		cur_name = names[i];
 		cur_name_len = strlen(cur_name);
 
 		ret = lgetxattr(file_name, cur_name, cur_value, XATTR_SIZE_MAX);
 		if (ret < 0) {
 			if (errno == ENOTSUP)
-				return 0;
-			error("getting a xattr value failed for %s attr %s: %m",
-				file_name, cur_name);
-			return ret;
+				ret = 0;
+			else
+				error("getting a xattr value failed for %s attr %s: %m",
+					file_name, cur_name);
+			goto out;
 		}
 
 		ret = btrfs_insert_xattr_item(trans, root, cur_name,
@@ -353,10 +381,9 @@ static int add_xattr_item(struct btrfs_trans_handle *trans,
 			error("inserting a xattr item failed for %s: %m",
 					file_name);
 		}
-
-		cur_name += cur_name_len + 1;
 	}
-
+out:
+	free(names);
 	return ret;
 }
 
@@ -1853,9 +1880,18 @@ static int ftw_add_inode(const char *full_path, const struct stat *st,
 	struct btrfs_inode_item inode_item = { 0 };
 	struct inode_entry *parent;
 	struct rootdir_subvol *rds;
-	const bool have_hard_links = (!S_ISDIR(st->st_mode) && st->st_nlink > 1);
+	bool have_hard_links;
 	u64 ino;
 	int ret;
+
+	/*
+	 * No stat (FTW_NS) or unreadable directory (FTW_DNR): abort rather
+	 * than dereference a NULL st.
+	 */
+	if (typeflag == FTW_NS || typeflag == FTW_DNR)
+		return -EPERM;
+
+	have_hard_links = (!S_ISDIR(st->st_mode) && st->st_nlink > 1);
 
 	/* The rootdir itself. */
 	if (unlikely(ftwbuf->level == 0)) {
@@ -2181,7 +2217,14 @@ int btrfs_mkfs_fill_dir(struct btrfs_trans_handle *trans, const char *source_dir
 	g_do_reflink = do_reflink;
 	INIT_LIST_HEAD(&current_path.inode_list);
 
-	ret = nftw(source_dir, ftw_add_inode, 32, FTW_PHYS);
+	/*
+	 * A reproducible image needs a sorted traversal, which costs extra
+	 * allocation and CPU. A regular mkfs doesn't, so use nftw() there.
+	 */
+	if (reproducible_is_enabled())
+		ret = path_sorted_walk(source_dir, ftw_add_inode);
+	else
+		ret = nftw(source_dir, ftw_add_inode, 32, FTW_PHYS);
 	if (ret) {
 		error("unable to traverse directory %s: %d", source_dir, ret);
 		return ret;
@@ -2278,11 +2321,16 @@ u64 btrfs_mkfs_size_dir(const char *dir_name, u32 sectorsize, u64 min_dev_size,
 	/*
 	 * Symbolic link is not followed when creating files, so no need to
 	 * follow them here.
+	 *
+	 * This pass only sums file sizes and counts inodes, a result that is
+	 * independent of walk order, so it always uses nftw() -- the sorted
+	 * walk (see btrfs_mkfs_fill_dir()) is only needed where the order
+	 * feeds the on-disk layout.
 	 */
 	ret = nftw(dir_name, ftw_add_entry_size, 10, FTW_PHYS);
 	rb_free_nodes(&hardlink_root, free_one_hardlink);
 	if (ret < 0) {
-		error("ftw subdir walk of %s failed: %m", dir_name);
+		error("unable to walk subdir of %s: %m", dir_name);
 		exit(1);
 	}
 

--- a/mkfs/rootdir.c
+++ b/mkfs/rootdir.c
@@ -51,6 +51,7 @@
 #include "common/messages.h"
 #include "common/utils.h"
 #include "common/extent-tree-utils.h"
+#include "common/reproducible.h"
 #include "common/root-tree-utils.h"
 #include "common/path-utils.h"
 #include "common/rbtree-utils.h"
@@ -274,6 +275,18 @@ static void free_one_hardlink(struct rb_node *node)
 
 static void stat_to_inode_item(struct btrfs_inode_item *dst, const struct stat *st)
 {
+	bool use_sde = reproducible_has_source_date();
+	time_t now = use_sde ? reproducible_now() : 0;
+	time_t atime = st->st_atime;
+	time_t ctime = st->st_ctime;
+	time_t mtime = st->st_mtime;
+
+	if (use_sde) {
+		ctime = now;
+		mtime = st->st_mtime < now ? st->st_mtime : now;
+		atime = now;
+	}
+
 	/*
 	 * Do not touch size for directory inode, the size would be
 	 * automatically updated during btrfs_link_inode().
@@ -287,11 +300,11 @@ static void stat_to_inode_item(struct btrfs_inode_item *dst, const struct stat *
 	btrfs_set_stack_inode_mode(dst, st->st_mode);
 	btrfs_set_stack_inode_rdev(dst, 0);
 	btrfs_set_stack_inode_flags(dst, 0);
-	btrfs_set_stack_timespec_sec(&dst->atime, st->st_atime);
+	btrfs_set_stack_timespec_sec(&dst->atime, atime);
 	btrfs_set_stack_timespec_nsec(&dst->atime, 0);
-	btrfs_set_stack_timespec_sec(&dst->ctime, st->st_ctime);
+	btrfs_set_stack_timespec_sec(&dst->ctime, ctime);
 	btrfs_set_stack_timespec_nsec(&dst->ctime, 0);
-	btrfs_set_stack_timespec_sec(&dst->mtime, st->st_mtime);
+	btrfs_set_stack_timespec_sec(&dst->mtime, mtime);
 	btrfs_set_stack_timespec_nsec(&dst->mtime, 0);
 	btrfs_set_stack_timespec_sec(&dst->otime, 0);
 	btrfs_set_stack_timespec_nsec(&dst->otime, 0);

--- a/tests/mkfs-tests/045-rootdir-reproducible-atime/test.sh
+++ b/tests/mkfs-tests/045-rootdir-reproducible-atime/test.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Verify that source atime updates do not change reproducible rootdir images.
+
+source "$TEST_TOP/common" || exit
+
+check_prereq mkfs.btrfs
+check_global_prereq cmp
+setup_root_helper
+
+setup_loopdevs 1
+prepare_loopdevs
+source_dev=${loopdevs[1]}
+
+run_check $SUDO_HELPER "$TOP/mkfs.btrfs" -f "$source_dev"
+run_check $SUDO_HELPER mount -t btrfs -o relatime "$source_dev" "$TEST_MNT"
+run_check $SUDO_HELPER chmod 0777 "$TEST_MNT"
+
+source_dir="$TEST_MNT/source"
+run_check mkdir "$source_dir"
+run_check dd if=/dev/zero of="$source_dir/file" bs=4096 count=1 status=none
+
+source_date_epoch=1700000000
+old_timestamp=$((source_date_epoch - 86400))
+run_check touch -d "@$old_timestamp" "$source_dir/file"
+
+image1=$(_mktemp mkfs-rootdir-atime-1)
+image2=$(_mktemp mkfs-rootdir-atime-2)
+fs_uuid=12345678-1234-1234-1234-123456789abc
+
+run_check env SOURCE_DATE_EPOCH="$source_date_epoch" DETERMINISTIC_SEED=1 \
+	"$TOP/mkfs.btrfs" -f -U "$fs_uuid" --rootdir "$source_dir" "$image1"
+
+source_atime=$(run_check_stdout stat --format=%X "$source_dir/file")
+if [[ "$source_atime" -le "$source_date_epoch" ]]; then
+	_fail "reading the source did not advance atime on the relatime mount"
+fi
+
+run_check env SOURCE_DATE_EPOCH="$source_date_epoch" DETERMINISTIC_SEED=1 \
+	"$TOP/mkfs.btrfs" -f -U "$fs_uuid" --rootdir "$source_dir" "$image2"
+run_check cmp "$image1" "$image2"
+
+run_check $SUDO_HELPER umount "$TEST_MNT"
+run_check $SUDO_HELPER mount -t btrfs -o loop,ro "$image2" "$TEST_MNT"
+
+image_times=$(run_check_stdout $SUDO_HELPER stat --format='%X %Y %Z' \
+	"$TEST_MNT/file")
+read -r image_atime image_mtime image_ctime <<< "$image_times"
+if [[ "$image_atime" -ne "$source_date_epoch" ]]; then
+	_fail "image atime $image_atime does not match SOURCE_DATE_EPOCH"
+fi
+if [[ "$image_ctime" -ne "$source_date_epoch" ]]; then
+	_fail "image ctime $image_ctime does not match SOURCE_DATE_EPOCH"
+fi
+if [[ "$image_mtime" -ne "$old_timestamp" ]]; then
+	_fail "image mtime $image_mtime does not preserve the older source mtime"
+fi
+
+run_check $SUDO_HELPER umount "$TEST_MNT"
+cleanup_loopdevs
+rm -f -- "$image1" "$image2"

--- a/tests/reproducibility-check.sh
+++ b/tests/reproducibility-check.sh
@@ -1,0 +1,411 @@
+#!/bin/bash
+#
+# Reproducibility check for mkfs.btrfs.
+#
+# Runs mkfs.btrfs (and `mkfs.btrfs --rootdir`) under a matrix of varied
+# environments and asserts the resulting images are byte-identical via
+# plain `cmp`. Prints a matrix of PASS/FAIL/SKIP and exits non-zero on
+# any unexpected failure.
+#
+# Requires root (uses loop-mounted filesystems for source-FS variation
+# and chown for uid variation).
+#
+# Usage: sudo bash tests/reproducibility-check.sh
+#
+
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+TOP=$(dirname "$SCRIPT_DIR")
+TEST_TOP="$SCRIPT_DIR"
+INTERNAL_BIN="$TOP"
+RESULTS="$TEST_TOP/reproducibility-tests-results.txt"
+export TOP TEST_TOP INTERNAL_BIN RESULTS
+
+: > "$RESULTS"
+
+# shellcheck disable=SC1091
+source "$TEST_TOP/common" || exit 1
+
+if [[ "$(id -u)" -ne 0 ]]; then
+	_fail "this script must run as root (uses loop-mounted filesystems)"
+fi
+
+MKFS="$TOP/mkfs.btrfs"
+if [[ ! -x "$MKFS" ]]; then
+	echo "Building mkfs.btrfs..."
+	(cd "$TOP" && make -j"$(nproc)" mkfs.btrfs >/dev/null) || \
+		_fail "failed to build mkfs.btrfs"
+fi
+
+# Pinned values used in all variations: a fixed fs UUID plus
+# SOURCE_DATE_EPOCH and DETERMINISTIC_SEED=1. This is the full
+# documented reproducible-build recipe; mkfs derives every other UUID
+# (device, chunk-tree, subvolumes) from the fs UUID.
+FIXED_UUID="12345678-1234-5678-1234-567812345678"
+FIXED_EPOCH="1700000000"
+
+WORK=$(mktemp -d -t btrfs-repro-XXXXXX)
+SOURCE_DIR="$WORK/source"
+MOUNTS=()
+
+cleanup() {
+	local mp
+	for mp in "${MOUNTS[@]}"; do
+		[[ -n "$mp" ]] && mountpoint -q "$mp" 2>/dev/null && \
+			umount "$mp" 2>/dev/null
+	done
+	rm -rf "$WORK"
+}
+
+# ----------------------------------------------------------------------
+# Source-tree generator. Produces a small but varied tree intended to
+# exercise the bits of the rootdir code that matter for reproducibility:
+# multiple directory levels, files of inline / single-block / multi-block
+# size, hardlinks, symlinks, sparse files, empty files.
+# ----------------------------------------------------------------------
+create_test_tree() {
+	local dest="$1"
+	mkdir -p "$dest"
+
+	local d f
+	for d in alpha beta gamma; do
+		mkdir -p "$dest/$d"
+		for f in one two three; do
+			printf 'content of %s/%s\n' "$d" "$f" > "$dest/$d/$f"
+		done
+		dd if=/dev/zero of="$dest/$d/block" bs=4K count=1 status=none
+		printf 'X%.0s' $(seq 1 65536) > "$dest/$d/multi"
+	done
+
+	ln -s "../alpha/one" "$dest/beta/sym_rel"
+	ln -s "/etc/hostname" "$dest/gamma/sym_abs"
+
+	ln "$dest/alpha/one" "$dest/gamma/hard_one"
+
+	touch "$dest/empty"
+
+	truncate -s 4M "$dest/sparse"
+	printf 'tail\n' >> "$dest/sparse"
+
+	mkdir -p "$dest/deep/a/b/c/d/e"
+	printf 'deep\n' > "$dest/deep/a/b/c/d/e/leaf"
+}
+
+normalize_source_dir() {
+	local dir="$1"
+	chown -R --no-dereference 0:0 "$dir"
+}
+
+create_test_tree "$SOURCE_DIR"
+normalize_source_dir "$SOURCE_DIR"
+
+# ----------------------------------------------------------------------
+# Image runner. Runs mkfs.btrfs twice with two distinct shell contexts
+# and cmp's the resulting images.
+#
+# Arguments:
+#   $1  label                            (e.g. "baseline")
+#   $2  use_rootdir                      ("yes" | "no")
+#   $3  context_a (shell snippet that, when eval'd, runs the mkfs)
+#   $4  context_b (shell snippet, ditto)
+#
+# The snippets must define the function _RUN_MKFS that takes one
+# argument (the image path).
+# ----------------------------------------------------------------------
+run_pair() {
+	local label="$1"
+	local mode="$2"
+	local ctx_a="$3"
+	local ctx_b="$4"
+
+	local img_a="$WORK/${label}_${mode}_a.img"
+	local img_b="$WORK/${label}_${mode}_b.img"
+	rm -f "$img_a" "$img_b"
+	truncate -s 256M "$img_a" "$img_b"
+
+	local ret_a=0 ret_b=0
+	(
+		eval "$ctx_a"
+		_RUN_MKFS "$img_a" >>"$RESULTS" 2>&1
+	) || ret_a=$?
+	(
+		eval "$ctx_b"
+		_RUN_MKFS "$img_b" >>"$RESULTS" 2>&1
+	) || ret_b=$?
+
+	local result
+	if [[ "$ret_a" -ne 0 || "$ret_b" -ne 0 ]]; then
+		# Avoid a false PASS from equal partially-written images.
+		result="ERR"
+	elif cmp -s "$img_a" "$img_b"; then
+		result="PASS"
+	else
+		result="FAIL"
+	fi
+
+	rm -f "$img_a" "$img_b"
+	echo "$result"
+}
+
+# Leave --device-uuid unset to test its derivation from -U.
+mkfs_empty() {
+	cat <<'EOF'
+_RUN_MKFS() {
+	SOURCE_DATE_EPOCH=$FIXED_EPOCH DETERMINISTIC_SEED=1 \
+		"$MKFS" -f -K -U "$FIXED_UUID" -L repro "$1"
+}
+EOF
+}
+
+# Select two installed locales so fallback cannot turn the test into a no-op.
+LOCALE_AVAILABLE=$(locale -a 2>/dev/null)
+LOCALE_A=""
+LOCALE_B=""
+for _locale in de_DE.UTF-8 fr_FR.UTF-8 ja_JP.UTF-8 \
+               en_US.UTF-8 en_US.utf8 en_GB.utf8 \
+               C.UTF-8 C.utf8 POSIX C; do
+	if printf '%s\n' "$LOCALE_AVAILABLE" | grep -qx "$_locale"; then
+		if [[ -z "$LOCALE_A" ]]; then
+			LOCALE_A="$_locale"
+		elif [[ -z "$LOCALE_B" ]]; then
+			LOCALE_B="$_locale"
+			break
+		fi
+	fi
+done
+unset _locale LOCALE_AVAILABLE
+export LOCALE_A LOCALE_B
+
+# Bake the source path into the snippet so each variation can select its tree.
+mkfs_rootdir() {
+	local src="$1"
+	cat <<EOF
+_RUN_MKFS() {
+	SOURCE_DATE_EPOCH=\$FIXED_EPOCH DETERMINISTIC_SEED=1 \\
+		"\$MKFS" -f -K -U "\$FIXED_UUID" -L repro \\
+		-r "$src" "\$1"
+}
+EOF
+}
+
+mkfs_rootdir_compress() {
+	local src="$1" algo="$2"
+	cat <<EOF
+_RUN_MKFS() {
+	SOURCE_DATE_EPOCH=\$FIXED_EPOCH DETERMINISTIC_SEED=1 \\
+		"\$MKFS" -f -K -U "\$FIXED_UUID" -L repro \\
+		--compress $algo -r "$src" "\$1"
+}
+EOF
+}
+
+# ----------------------------------------------------------------------
+# Variations. Each function prints PASS or FAIL on one line for the
+# requested mode (empty | rootdir). SKIP if not applicable.
+# ----------------------------------------------------------------------
+
+var_baseline() {
+	local mode="$1"
+	local runner
+	if [[ "$mode" == "empty" ]]; then runner=$(mkfs_empty)
+	else runner=$(mkfs_rootdir "$SOURCE_DIR"); fi
+	run_pair "baseline" "$mode" "$runner" "$runner"
+}
+
+var_clock() {
+	local mode="$1"
+	local runner
+	if [[ "$mode" == "empty" ]]; then runner=$(mkfs_empty)
+	else runner=$(mkfs_rootdir "$SOURCE_DIR"); fi
+	# Ensure time(NULL) differs between runs.
+	run_pair "clock" "$mode" "$runner" "sleep 2; $runner"
+}
+
+var_tz() {
+	local mode="$1"
+	local runner
+	if [[ "$mode" == "empty" ]]; then runner=$(mkfs_empty)
+	else runner=$(mkfs_rootdir "$SOURCE_DIR"); fi
+	run_pair "tz" "$mode" "export TZ=Asia/Tokyo; $runner" \
+		"export TZ=Europe/Berlin; $runner"
+}
+
+var_locale() {
+	local mode="$1"
+	if [[ -z "$LOCALE_A" || -z "$LOCALE_B" ]]; then
+		echo "SKIP"
+		return
+	fi
+	local runner
+	if [[ "$mode" == "empty" ]]; then runner=$(mkfs_empty)
+	else runner=$(mkfs_rootdir "$SOURCE_DIR"); fi
+	run_pair "locale" "$mode" \
+		"export LANG=$LOCALE_A LC_ALL=$LOCALE_A; $runner" \
+		"export LANG=$LOCALE_B LC_ALL=$LOCALE_B; $runner"
+}
+
+var_umask() {
+	local mode="$1"
+	local runner
+	if [[ "$mode" == "empty" ]]; then runner=$(mkfs_empty)
+	else runner=$(mkfs_rootdir "$SOURCE_DIR"); fi
+	run_pair "umask" "$mode" "umask 022; $runner" "umask 077; $runner"
+}
+
+var_cwd() {
+	local mode="$1"
+	local cwd_a="$WORK/cwd-a"
+	local cwd_b="$WORK/cwd-b"
+	mkdir -p "$cwd_a" "$cwd_b"
+	local runner
+	if [[ "$mode" == "empty" ]]; then runner=$(mkfs_empty)
+	else runner=$(mkfs_rootdir "$SOURCE_DIR"); fi
+	run_pair "cwd" "$mode" "cd '$cwd_a'; $runner" "cd '$cwd_b'; $runner"
+}
+
+# Exercise the documented ownership normalization from two starting owners.
+var_uid() {
+	local mode="$1"
+	if [[ "$mode" == "empty" ]]; then echo "SKIP"; return; fi
+	local src_a="$WORK/src-uid-a"
+	local src_b="$WORK/src-uid-b"
+	rm -rf "$src_a" "$src_b"
+	cp -a "$SOURCE_DIR" "$src_a"
+	cp -a "$SOURCE_DIR" "$src_b"
+	chown -R 1000:1000 "$src_a"
+	chown -R 2000:2000 "$src_b"
+	normalize_source_dir "$src_a"
+	normalize_source_dir "$src_b"
+	run_pair "uid" "$mode" \
+		"$(mkfs_rootdir "$src_a")" \
+		"$(mkfs_rootdir "$src_b")"
+}
+
+# Compare identical source trees staged on ext4 and XFS.
+var_source_fs() {
+	local mode="$1"
+	if [[ "$mode" == "empty" ]]; then echo "SKIP"; return; fi
+
+	local img_ext4="$WORK/src-ext4.img"
+	local img_xfs="$WORK/src-xfs.img"
+	local mnt_ext4="$WORK/mnt-ext4"
+	local mnt_xfs="$WORK/mnt-xfs"
+
+	mkdir -p "$mnt_ext4" "$mnt_xfs"
+	truncate -s 256M "$img_ext4" "$img_xfs"
+
+	if ! command -v mkfs.ext4 >/dev/null || \
+	   ! command -v mkfs.xfs  >/dev/null; then
+		echo "SKIP"
+		return
+	fi
+
+	mkfs.ext4 -q -F "$img_ext4" >/dev/null 2>&1 || { echo "SKIP"; return; }
+	mkfs.xfs  -q -f "$img_xfs"  >/dev/null 2>&1 || { echo "SKIP"; return; }
+
+	mount -o loop "$img_ext4" "$mnt_ext4" || { echo "SKIP"; return; }
+	MOUNTS+=("$mnt_ext4")
+	mount -o loop "$img_xfs"  "$mnt_xfs"  || { echo "SKIP"; return; }
+	MOUNTS+=("$mnt_xfs")
+
+	# Remove ext4-only content so the source trees match.
+	rm -rf "$mnt_ext4/lost+found"
+
+	cp -a "$SOURCE_DIR/." "$mnt_ext4/"
+	cp -a "$SOURCE_DIR/." "$mnt_xfs/"
+	normalize_source_dir "$mnt_ext4"
+	normalize_source_dir "$mnt_xfs"
+
+	local result
+	result=$(run_pair "source_fs" "$mode" \
+		"$(mkfs_rootdir "$mnt_ext4")" \
+		"$(mkfs_rootdir "$mnt_xfs")")
+
+	umount "$mnt_ext4"
+	umount "$mnt_xfs"
+	# Drop the entries we just unmounted from the cleanup list.
+	MOUNTS=("${MOUNTS[@]/$mnt_ext4}")
+	MOUNTS=("${MOUNTS[@]/$mnt_xfs}")
+
+	echo "$result"
+}
+
+# Use enough compressible data to exercise each compressor's output path.
+var_compress() {
+	local mode="$1"
+	if [[ "$mode" == "empty" ]]; then echo "SKIP"; return; fi
+
+	local csrc="$WORK/csrc"
+	if [[ ! -e "$csrc/seq" ]]; then
+		mkdir -p "$csrc"
+		seq 1 4000000 > "$csrc/seq"
+		normalize_source_dir "$csrc"
+	fi
+
+	local algo res overall=SKIP
+	for algo in zlib lzo zstd; do
+		res=$(run_pair "compress_$algo" "$mode" \
+			"$(mkfs_rootdir_compress "$csrc" "$algo")" \
+			"$(mkfs_rootdir_compress "$csrc" "$algo")")
+		case "$res" in
+		PASS) [[ "$overall" == FAIL ]] || overall=PASS ;;
+		FAIL) overall=FAIL ;;
+		ERR)  ;;	# algo not built into this mkfs; skip it
+		esac
+	done
+	echo "$overall"
+}
+
+# ----------------------------------------------------------------------
+# Driver: run every variation in both modes, collect into a matrix.
+# ----------------------------------------------------------------------
+
+VARIATIONS=(baseline clock tz locale umask cwd uid source_fs compress)
+# CPU-count and cross-architecture (page size) are not in the matrix:
+# sysconf(_SC_NPROCESSORS_ONLN) can't be varied via taskset (it reads
+# /sys), and cross-arch needs separate hardware. Both are verified by
+# hand instead.
+
+declare -A EMPTY_RESULT
+declare -A ROOTDIR_RESULT
+
+for v in "${VARIATIONS[@]}"; do
+	echo -n "  $v ... "
+	EMPTY_RESULT[$v]=$("var_$v" empty)
+	ROOTDIR_RESULT[$v]=$("var_$v" rootdir)
+	echo "empty=${EMPTY_RESULT[$v]} rootdir=${ROOTDIR_RESULT[$v]}"
+done
+
+# ----------------------------------------------------------------------
+# Print final matrix.
+# ----------------------------------------------------------------------
+
+echo
+echo "Reproducibility matrix"
+echo "---------------------------------------------"
+printf '%-15s %-8s %-10s\n' "Variation" "Empty" "--rootdir"
+echo "---------------------------------------------"
+total=0
+passed=0
+for v in "${VARIATIONS[@]}"; do
+	e=${EMPTY_RESULT[$v]}
+	r=${ROOTDIR_RESULT[$v]}
+	printf '%-15s %-8s %-10s\n' "$v" "$e" "$r"
+	for cell in "$e" "$r"; do
+		case "$cell" in
+		PASS) total=$((total + 1)); passed=$((passed + 1)) ;;
+		FAIL) total=$((total + 1)) ;;
+		ERR)  total=$((total + 1)) ;;
+		SKIP) ;;
+		esac
+	done
+done
+echo "---------------------------------------------"
+echo "Result: $passed / $total passing"
+echo
+echo "Full log: $RESULTS"
+
+if [[ "$passed" -ne "$total" ]]; then
+	exit 1
+fi
+cleanup
+exit 0


### PR DESCRIPTION
Make `mkfs.btrfs` produce byte-for-byte identical images from identical
inputs (same binary, args, and source tree), for supply-chain verification,
build caching, and meaningful image diffs.

Block placement was already deterministic; this series plugs the remaining
non-determinism sources.

## Interface

No new CLI flags — two environment variables (same convention as the
reproducible-builds ecosystem and xfsprogs):

- `SOURCE_DATE_EPOCH=<unix_ts>` — pins all timestamps.
- `DETERMINISTIC_SEED=1` — opt into deterministic UUID derivation (requires a
  fixed `-U`; errors out if missing instead of silently emitting random UUIDs).

The `-U` UUID is the seed; all other internal UUIDs derive from it.

```
chown -R 0:0 ./rootfs              # caller normalizes ownership
truncate -s 1G img.btrfs           # fresh, zeroed target
SOURCE_DATE_EPOCH=1700000000 DETERMINISTIC_SEED=1 \
    mkfs.btrfs -f -U <uuid> -r ./rootfs img.btrfs
```

## What's fixed (one per commit)

- `time(NULL)` root-item timestamps → `SOURCE_DATE_EPOCH`.
- Random UUIDs (chunk-tree, FS_TREE, per-device, per-subvol) → derived from the
  fs UUID as `SHA256(fs_uuid || role || key)`, kept unique for
  multi-device/multi-subvol correctness.
- Host leaks: `nr_global_roots` (CPU count) and `BIG_METADATA` (page size) made
  host-independent.
- `-r` source file `atime/ctime/mtime` → `SOURCE_DATE_EPOCH` (ctime can't be
  normalized externally).
- `-r` directory order: `nftw()` (filesystem-dependent) replaced with a
  name-sorted walker, so the same tree on ext4/xfs/tmpfs yields the same image.

Ownership is left to the caller (`chown`) since the value is image-semantic.

## Testing

Includes `tests/reproducibility-check.sh` (root-required). Verified
byte-identical across ext4-vs-xfs source, multi-device, all csum types,
nodesize/sectorsize/compression/features, special files/xattrs/ACLs, allocator
perturbation, ASLR, and TZ/locale/umask/cwd.

## Caveats

- Target must be fresh/zeroed (mkfs doesn't scrub free space, like mkfs.ext4).
- `--compress` output also depends on the compression library version.
