### PR TITLE
btrfs-progs: scrub: update the error message to reduce confusion

### DIFF
--- a/cmds/scrub.c
+++ b/cmds/scrub.c
@@ -1727,7 +1727,7 @@ out:
 	if (nothing_to_resume)
 		return 2;
 	if (e_uncorrectable) {
-		error("there are %d uncorrectable errors", e_uncorrectable);
+		error("there are %d device(s) with uncorrectable errors", e_uncorrectable);
 		return 3;
 	}
 	if (e_correctable)


### PR DESCRIPTION
[BUG]
There is a bug report that scrub is reporting confusing and conflicting messages:

 $ sudo btrfs scrub start -B /mnt
 Starting scrub on devid 1
 scrub done for 44cb181f-faf6-48c2-a462-904cfe493576
 Scrub started:    Fri May 29 23:54:53 2026
 Status:           finished
 Duration:         0:10:23
 Total to scrub:   911.45GiB
 Rate:             1.46GiB/s
 Error summary:    csum=18
   Corrected:      0
   Uncorrectable:  18
   Unverified:     0
 ERROR: there are 1 uncorrectable errors

There are 18 uncorrectable errors, but the final line only shows one.

[CAUSE]
The "1" is for the number of devices with uncorrectable errors, not the total errors found in the device.

[FIX]
Change the error message to "there are 1 device(s) with uncorrectable errors" instead.