### PR TITLE
Various fixes reported by code scanning tools

### DIFF
--- a/cmds/restore.c
+++ b/cmds/restore.c
@@ -53,6 +53,7 @@
 #include "common/help.h"
 #include "common/open-utils.h"
 #include "common/string-utils.h"
+#include "common/path-utils.h"
 #include "common/messages.h"
 #include "cmds/commands.h"
 
@@ -983,14 +984,22 @@ static int search_dir(struct btrfs_root *root, struct btrfs_key *key,
 		type = btrfs_dir_ftype(leaf, dir_item);
 		btrfs_dir_item_key_to_cpu(leaf, dir_item, &location);
 
-		/* full path from root of btrfs being restored */
-		snprintf(fs_name, PATH_MAX, "%s/%s", in_dir, filename);
+		/* Full path from root of filesystem being restored. */
+		ret = path_cat_out(fs_name, in_dir, filename);
+		if (ret < 0) {
+			error("invalid file path %s/%s", in_dir, filename);
+			goto out;
+		}
 
 		if (mreg && REG_NOMATCH == regexec(mreg, fs_name, 0, NULL, 0))
 			goto next;
 
-		/* full path from system root */
-		snprintf(path_name, PATH_MAX, "%s%s", output_rootdir, fs_name);
+		/* Full path from system root. */
+		ret = path_cat_out(path_name, output_rootdir, fs_name);
+		if (ret < 0) {
+			error("invalid full path %s%s", output_rootdir, fs_name);
+			goto out;
+		}
 
 		/*
 		 * Restore directories, files, symlinks and metadata.
@@ -1105,7 +1114,11 @@ next:
 	}
 
 	if ((restore_metadata || get_xattrs) && !dry_run) {
-		snprintf(path_name, PATH_MAX, "%s%s", output_rootdir, in_dir);
+		ret = path_cat_out(path_name, output_rootdir, in_dir);
+		if (ret < 0) {
+			error("invalid path %s%s", output_rootdir, in_dir);
+			goto out;
+		}
 		fd = open(path_name, O_RDONLY);
 		if (fd < 0) {
 			error("failed to access '%s' to restore metadata/xattrs: %m",

--- a/cmds/subvolume.c
+++ b/cmds/subvolume.c
@@ -430,8 +430,12 @@ static int cmd_subvolume_delete(const struct cmd_struct *cmd, int argc, char **a
 			goto out;
 		}
 
-		/* Build new path using the volume name found */
-		sprintf(full_subvolpath, "%s/%s", path, subvol);
+		/* Build new path using the volume name found. */
+		ret = path_cat_out(full_subvolpath, path, subvol);
+		if (ret < 0) {
+			error("invalid subvolume path %s/%s", path, subvol);
+			goto out;
+		}
 		free(subvol);
 	}
 

--- a/common/array.c
+++ b/common/array.c
@@ -86,7 +86,7 @@ int array_append(struct array *arr, void *element)
 	if (arr->length == arr->capacity) {
 		void **tmp;
 
-		tmp = realloc(arr->data, (arr->capacity + alloc_increment) * sizeof(void *));
+		tmp = reallocarray(arr->data, arr->capacity + alloc_increment, sizeof(void *));
 		if (!tmp)
 			return -1;
 		arr->data = tmp;

--- a/common/array.c
+++ b/common/array.c
@@ -40,8 +40,10 @@ int array_init(struct array *arr, unsigned int capacity)
 		arr->capacity = alloc_increment;
 
 	tmp = calloc(arr->capacity, sizeof(void *));
-	if (!tmp)
+	if (!tmp) {
+		arr->capacity = 0;
 		return -1;
+	}
 	arr->data = tmp;
 	return 0;
 }

--- a/common/array.c
+++ b/common/array.c
@@ -88,6 +88,9 @@ int array_append(struct array *arr, void *element)
 	if (arr->length == arr->capacity) {
 		void **tmp;
 
+		if (arr->capacity + alloc_increment < arr->capacity)
+			return -1;
+
 		tmp = reallocarray(arr->data, arr->capacity + alloc_increment, sizeof(void *));
 		if (!tmp)
 			return -1;

--- a/common/array.c
+++ b/common/array.c
@@ -51,6 +51,8 @@ int array_init(struct array *arr, unsigned int capacity)
 /* Free internal data array. */
 void array_free(struct array *arr)
 {
+	if (!arr)
+		return;
 	free(arr->data);
 	arr->length = 0;
 	arr->capacity = 0;
@@ -62,6 +64,8 @@ void array_free_elements(struct array *arr)
 {
 	unsigned int i;
 
+	if (!arr)
+		return;
 	for (i = 0; i < arr->length; i++) {
 		free(arr->data[i]);
 		arr->data[i] = NULL;
@@ -72,6 +76,8 @@ void array_free_elements(struct array *arr)
 /* Reset all elements to NULL up to capacity. */
 void array_clear(struct array *arr)
 {
+	if (!arr)
+		return;
 	for (unsigned int i = 0; i < arr->capacity; i++)
 		arr->data[i] = NULL;
 }
@@ -79,12 +85,16 @@ void array_clear(struct array *arr)
 /* Use the whole capacity for elements. */
 void array_use_capacity(struct array *arr)
 {
+	if (!arr)
+		return;
 	arr->length = arr->capacity;
 }
 
 /* Append a new element (increase length), extend the array if needed. */
 int array_append(struct array *arr, void *element)
 {
+	if (!arr)
+		return 0;
 	if (arr->length == arr->capacity) {
 		void **tmp;
 

--- a/common/clear-cache.c
+++ b/common/clear-cache.c
@@ -693,8 +693,10 @@ static int check_space_cache(struct btrfs_root *root, struct task_ctx *task_ctx)
 
 	extent_io_tree_init(fs_info, &used, 0);
 	ret = btrfs_mark_used_blocks(fs_info, &used);
-	if (ret)
-		return ret;
+	if (ret) {
+		error = ret;
+		goto out;
+	}
 
 	while (1) {
 		task_ctx->item_count++;
@@ -758,6 +760,7 @@ static int check_space_cache(struct btrfs_root *root, struct task_ctx *task_ctx)
 			error++;
 		}
 	}
+out:
 	extent_io_tree_release(&used);
 	return error ? -EINVAL : 0;
 }

--- a/common/device-scan.c
+++ b/common/device-scan.c
@@ -218,6 +218,7 @@ int btrfs_add_to_fsid(struct btrfs_trans_handle *trans,
 
 out:
 	free(device->zone_info);
+	free(device->name);
 	free(device);
 	free(buf);
 	return ret;

--- a/common/device-scan.c
+++ b/common/device-scan.c
@@ -58,10 +58,11 @@ static int btrfs_scan_done = 0;
 
 /*
  * This function checks if the given input parameter is
- * an uuid or a path
- * return <0 : some error in the given input
+ * a UUID or a path:
+ *
+ * return <0:                   some error in the given input
  * return BTRFS_ARG_UNKNOWN:	unknown input
- * return BTRFS_ARG_UUID:	given input is uuid
+ * return BTRFS_ARG_UUID:	given input is UUID
  * return BTRFS_ARG_MNTPOINT:	given input is path
  * return BTRFS_ARG_REG:	given input is regular file
  * return BTRFS_ARG_BLKDEV:	given input is block device
@@ -85,12 +86,9 @@ int check_arg_type(const char *input)
 			return BTRFS_ARG_REG;
 
 		return BTRFS_ARG_UNKNOWN;
-	} else {
-		return -errno;
 	}
 
-	if (strlen(input) == (BTRFS_UUID_UNPARSED_SIZE - 1) &&
-		!uuid_parse(input, uuid))
+	if (strlen(input) == (BTRFS_UUID_UNPARSED_SIZE - 1) && uuid_parse(input, uuid) == 0)
 		return BTRFS_ARG_UUID;
 
 	return BTRFS_ARG_UNKNOWN;

--- a/common/format-output.c
+++ b/common/format-output.c
@@ -85,13 +85,13 @@ static void print_escaped(const char *str)
 
 static void fmt_indent1(int indent)
 {
-	while (indent--)
+	while (indent-- > 0)
 		putchar(' ');
 }
 
 static void fmt_indent2(int indent)
 {
-	while (indent--) {
+	while (indent-- > 0) {
 		putchar(' ');
 		putchar(' ');
 	}

--- a/common/open-utils.c
+++ b/common/open-utils.c
@@ -53,7 +53,7 @@ static int blk_file_in_dev_list(struct btrfs_fs_devices* fs_devices,
 	return 0;
 }
 
-int check_mounted_where(int fd, const char *file, char *where, int size,
+int check_mounted_where(int fd, const char *file, char *where, size_t size,
 			struct btrfs_fs_devices **fs_dev_ret, unsigned sbflags,
 			bool noscan)
 {

--- a/common/open-utils.h
+++ b/common/open-utils.h
@@ -23,7 +23,7 @@
 
 struct btrfs_fs_devices;
 
-int check_mounted_where(int fd, const char *file, char *where, int size,
+int check_mounted_where(int fd, const char *file, char *where, size_t size,
 			struct btrfs_fs_devices **fs_dev_ret, unsigned sbflags,
 			bool noscan);
 int check_mounted(const char* file);

--- a/common/path-utils.c
+++ b/common/path-utils.c
@@ -430,7 +430,7 @@ int path_cat_out(char *out, const char *p1, const char *p2)
 		p1_len--;
 	if (p2_len && p2[p2_len - 1] == '/')
 		p2_len--;
-	sprintf(out, "%.*s/%.*s", p1_len, p1, p2_len, p2);
+	snprintf(out, PATH_MAX, "%.*s/%.*s", p1_len, p1, p2_len, p2);
 
 	return 0;
 }
@@ -450,7 +450,7 @@ int path_cat3_out(char *out, const char *p1, const char *p2, const char *p3)
 		p2_len--;
 	if (p3_len && p3[p3_len - 1] == '/')
 		p3_len--;
-	sprintf(out, "%.*s/%.*s/%.*s", p1_len, p1, p2_len, p2, p3_len, p3);
+	snprintf(out, PATH_MAX, "%.*s/%.*s/%.*s", p1_len, p1, p2_len, p2, p3_len, p3);
 
 	return 0;
 }

--- a/common/root-tree-utils.c
+++ b/common/root-tree-utils.c
@@ -136,7 +136,8 @@ int btrfs_link_subvolume(struct btrfs_trans_handle *trans,
 	u32 imode;
 	int ret;
 
-	UASSERT(namelen && namelen <= BTRFS_NAME_LEN);
+	if (namelen <= 0 || namelen > BTRFS_NAME_LEN)
+		return -EINVAL;
 
 	/* Make sure @parent_dir is a directory. */
 	key.objectid = parent_dir;

--- a/common/send-stream.c
+++ b/common/send-stream.c
@@ -76,6 +76,8 @@ static int read_buf(struct btrfs_send_stream *sctx, char *buf, size_t len)
 
 		rbytes = read(sctx->fd, buf + pos, len - pos);
 		if (rbytes < 0) {
+			if (errno == EINTR)
+				continue;
 			ret = -errno;
 			error("read from stream failed: %m");
 			goto out;

--- a/common/send-stream.c
+++ b/common/send-stream.c
@@ -196,6 +196,11 @@ static int read_cmd(struct btrfs_send_stream *sctx)
 
 		pos += sizeof(tlv_type);
 		data += sizeof(tlv_type);
+		if (cmd_len < pos) {
+			error("send stream is truncated");
+			ret = -EINVAL;
+			goto out;
+		}
 		if (sctx->version >= 2 && tlv_type == BTRFS_SEND_A_DATA) {
 			send_attr->tlv_len = cmd_len - pos;
 		} else {
@@ -208,7 +213,7 @@ static int read_cmd(struct btrfs_send_stream *sctx)
 			pos += sizeof(__le16);
 			data += sizeof(__le16);
 		}
-		if (cmd_len - pos < send_attr->tlv_len) {
+		if (cmd_len < pos || cmd_len - pos < send_attr->tlv_len) {
 			error("send stream is truncated");
 			ret = -EINVAL;
 			goto out;

--- a/common/send-stream.c
+++ b/common/send-stream.c
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <kernel-lib/overflow.h>
 #include "kernel-shared/uapi/btrfs_tree.h"
 #include "kernel-shared/uapi/btrfs.h"
 #include "kernel-shared/send.h"
@@ -134,7 +135,11 @@ static int read_cmd(struct btrfs_send_stream *sctx)
 	cmd_hdr = (struct btrfs_cmd_header *)sctx->read_buf;
 	cmd_len = get_unaligned_le32(&cmd_hdr->len);
 	cmd = get_unaligned_le16(&cmd_hdr->cmd);
-	buf_len = sizeof(*cmd_hdr) + cmd_len;
+	if (check_add_overflow(sizeof(*cmd_hdr), (size_t)cmd_len, &buf_len)) {
+		ret = -EOVERFLOW;
+		error("command length overflow");
+		goto out;
+	}
 	if (sctx->read_buf_size < buf_len) {
 		void *new_read_buf;
 

--- a/common/utils.c
+++ b/common/utils.c
@@ -225,7 +225,7 @@ int get_fs_info(const char *path, struct btrfs_ioctl_fs_info_args *fi_args,
 	if (!fi_args->num_devices)
 		goto out;
 
-	di_args = *di_ret = malloc((fi_args->num_devices) * sizeof(*di_args));
+	di_args = *di_ret = calloc(fi_args->num_devices, sizeof(*di_args));
 	if (!di_args) {
 		ret = -errno;
 		goto out;


### PR DESCRIPTION
- **btrfs-progs: use path API for path building**
- **btrfs-progs: harden path building and limit length to PATH_MAX**
- **btrfs-progs: receive: handle more cases of incomplete stream**
- **btrfs-progs: use safe array realloc helper for dynamic array**
- **btrfs-progs: reset capacity if array allocation fails**
- **btrfs-progs: verify new array size before appending new item**
- **btrfs-progs: accept NULL for the array API**
- **btrfs-progs: fix memory leak on error path in check_space_cache()**
- **btrfs-progs: fix check_arg_type() to recognize UUIDs**
- **btrfs-progs: fix minor memory leak of device path in btrfs_add_to_fsid()**
- **btrfs-progs: format-output: add lower bounds for indentation**
- **btrfs-progs: use unsigned size type in check_mounted_where()**
- **btrfs-progs: validate new subvolume length**
- **btrfs-progs: send-stream: check size before reading in read_cmd()**
- **btrfs-progs: send-stream: handle EINTR during buffer reads**
- **btrfs-progs: use safer allocation in get_fs_info()**
