### PR TITLE
Asan fixes

### DIFF
--- a/common/device-utils.c
+++ b/common/device-utils.c
@@ -302,12 +302,12 @@ int btrfs_prepare_device(int fd, const char *file, u64 *byte_count_ret,
 		goto err;
 	}
 
-	free(zinfo);
+	btrfs_free_zoned_device_info(zinfo);
 	*byte_count_ret = byte_count;
 	return 0;
 
 err:
-	free(zinfo);
+	btrfs_free_zoned_device_info(zinfo);
 	return 1;
 }
 

--- a/kernel-shared/volumes.c
+++ b/kernel-shared/volumes.c
@@ -648,7 +648,7 @@ again:
 		/* free the memory */
 		kfree(device->name);
 		kfree(device->label);
-		kfree(device->zone_info);
+		btrfs_free_zoned_device_info(device->zone_info);
 		kfree(device);
 	}
 

--- a/kernel-shared/volumes.c
+++ b/kernel-shared/volumes.c
@@ -2396,8 +2396,10 @@ again:
 
 			ret = btrfs_stripe_tree_logical_to_physical(fs_info, logical,
 								    &multi->stripes[i]);
-			if (ret)
+			if (ret) {
+				kfree(multi);
 				return ret;
+			}
 		} else {
 			multi->stripes[i].physical =
 				map->stripes[stripe_index].physical +

--- a/kernel-shared/zoned.c
+++ b/kernel-shared/zoned.c
@@ -1302,6 +1302,7 @@ out:
 	if (!ret)
 		cache->write_offset = cache->alloc_offset;
 
+	kfree(active);
 	kfree(zone_info);
 	return ret;
 }

--- a/kernel-shared/zoned.c
+++ b/kernel-shared/zoned.c
@@ -1464,7 +1464,7 @@ int btrfs_get_zone_info(int fd, const char *file,
 	/* Get zone information */
 	ret = report_zones(fd, file, zinfo);
 	if (ret != 0) {
-		kfree(zinfo);
+		btrfs_free_zoned_device_info(zinfo);
 		return ret;
 	}
 	*zinfo_ret = zinfo;

--- a/kernel-shared/zoned.h
+++ b/kernel-shared/zoned.h
@@ -83,6 +83,16 @@ enum btrfs_zoned_model zoned_model(const char *file);
 u64 zone_size(const char *file);
 int btrfs_get_zone_info(int fd, const char *file,
 			struct btrfs_zoned_device_info **zinfo);
+
+static inline void btrfs_free_zoned_device_info(struct btrfs_zoned_device_info *zinfo)
+{
+	if (!zinfo)
+		return;
+	free(zinfo->zones);
+	free(zinfo->active_zones);
+	free(zinfo);
+}
+
 int btrfs_get_dev_zone_info_all_devices(struct btrfs_fs_info *fs_info);
 int btrfs_check_zoned_mode(struct btrfs_fs_info *fs_info);
 


### PR DESCRIPTION
Just give a full test run (except libbtrfsutil run) with D=asan, all kinds of
memory leaks related to zone/RST are exposed.

Fix them one by one.