### PR TITLE
btrfs-progs: mkfs: dedupe hardlinks when estimating rootdir size

### DIFF
--- a/mkfs/rootdir.c
+++ b/mkfs/rootdir.c
@@ -206,8 +206,6 @@ static int hardlink_compare_nodes(const struct rb_node *node1,
 
 	entry1 = rb_entry(node1, struct hardlink_entry, node);
 	entry2 = rb_entry(node2, struct hardlink_entry, node);
-	UASSERT(entry1->root);
-	UASSERT(entry2->root);
 
 	if (entry1->st_dev < entry2->st_dev)
 		return -1;
@@ -2213,6 +2211,8 @@ fallback:
 static int ftw_add_entry_size(const char *fpath, const struct stat *st,
 			      int type, struct FTW *ftwbuf)
 {
+	int ret;
+
 	/*
 	 * Failed to read the directory, mostly due to EPERM.  Abort ASAP, so
 	 * we don't need to populate the fs.
@@ -2220,9 +2220,26 @@ static int ftw_add_entry_size(const char *fpath, const struct stat *st,
 	if (type == FTW_DNR || type == FTW_NS)
 		return -EPERM;
 
-	if (S_ISREG(st->st_mode))
-		add_data_size(fpath, st);
 	ftw_meta_nr_inode++;
+
+	if (S_ISREG(st->st_mode) && st->st_size > 0) {
+		/*
+		 * Skip hard links whose backing inode has already been
+		 * accounted for to avoid overestimating the data size.
+		 */
+		if (st->st_nlink > 1) {
+			ret = add_hard_link(NULL, 0, st);
+			if (ret == -EEXIST)
+				return 0;
+			if (ret < 0) {
+				errno = -ret;
+				error("failed to add hard link record for '%s': %m",
+				       fpath);
+				return ret;
+			}
+		}
+		add_data_size(fpath, st);
+	}
 
 	return 0;
 }
@@ -2252,6 +2269,7 @@ u64 btrfs_mkfs_size_dir(const char *dir_name, u32 sectorsize, u64 min_dev_size,
 	 * follow them here.
 	 */
 	ret = nftw(dir_name, ftw_add_entry_size, 10, FTW_PHYS);
+	rb_free_nodes(&hardlink_root, free_one_hardlink);
 	if (ret < 0) {
 		error("ftw subdir walk of %s failed: %m", dir_name);
 		exit(1);

--- a/tests/mkfs-tests/044-rootdir-hardlink-size/test.sh
+++ b/tests/mkfs-tests/044-rootdir-hardlink-size/test.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# Test that "mkfs.btrfs --rootdir" correctly estimates the device size when the
+# source directory contains many hardlinks to the same file.  Without inode
+# deduplication in the size-estimation pass, each hardlink was counted
+# individually, greatly overestimating the required size and causing the output
+# file to grow unnecessarily.
+
+source "$TEST_TOP/common" || exit
+
+check_prereq mkfs.btrfs
+check_prereq btrfs
+
+# Create the rootdir with one 10 MB file and 100 hardlinks to it.
+rootdir="$(_mktemp_dir mkfs-rootdir-hardlink-size)"
+run_check fallocate -l 10M "${rootdir}/bigfile"
+for i in $(seq 1 100); do
+	run_check ln "${rootdir}/bigfile" "${rootdir}/hardlink-$i"
+done
+
+# Create a test image sized to 1 GiB.
+prepare_test_dev 1G
+
+# First test with --shrink: verify the result is well below 1G.
+run_check "$TOP/mkfs.btrfs" --shrink --rootdir "$rootdir" "$TEST_DEV"
+run_check "$TOP/btrfs" check "$TEST_DEV"
+
+img_size="$(run_check_stdout stat --format=%s "$TEST_DEV")"
+sb_total="$(run_check_stdout "$TOP/btrfs" inspect-internal dump-super "$TEST_DEV" |
+	awk '/^[[:space:]]*total_bytes[[:space:]]/{print $2; exit}')"
+
+if [ "$img_size" -ne "$sb_total" ]; then
+	_fail "shrink: image size $img_size != total_bytes $sb_total"
+fi
+if [ "$img_size" -ge $((1 * 1024 * 1024 * 1024)) ]; then
+	_fail "shrink: image size $img_size >= 1 GiB, shrink did not work"
+fi
+
+# Reuse the device at the shrunk size for the non-shrink test.
+# If the size estimation correctly deduplicates hardlinks, the data should fit
+# without growing the image.
+prepare_test_dev "$img_size"
+run_check "$TOP/mkfs.btrfs" --rootdir "$rootdir" "$TEST_DEV"
+run_check "$TOP/btrfs" check "$TEST_DEV"
+
+img_size2="$(run_check_stdout stat --format=%s "$TEST_DEV")"
+sb_total2="$(run_check_stdout "$TOP/btrfs" inspect-internal dump-super "$TEST_DEV" |
+	awk '/^[[:space:]]*total_bytes[[:space:]]/{print $2; exit}')"
+
+if [ "$img_size2" -ne "$sb_total2" ]; then
+	_fail "non-shrink: image size $img_size2 != total_bytes $sb_total2"
+fi
+if [ "$img_size2" -gt "$img_size" ]; then
+	_fail "non-shrink: image size $img_size2 grew beyond shrunk size $img_size"
+fi
+
+rm -rf -- "$rootdir"


### PR DESCRIPTION
Previously, ftw_add_entry_size() counted every hard link to a file as separate data, greatly overestimating the required device size for directories with many hard links to the same inode.

Track visited inodes (by st_dev/st_ino) in an rbtree during the size-estimation walk, and skip accounting for inodes already seen. Only inodes with st_nlink > 1 are checked, since single-link files cannot be duplicates.

Add a test that creates 100 hard links to a 10 MB file and verifies that mkfs.btrfs --rootdir does not grossly overestimate the required image size.

Fixes #1141.