### PR TITLE
btrfs-progs: check: allow checksummed extents for NODATASUM inodes

### DIFF
--- a/check/main.c
+++ b/check/main.c
@@ -881,8 +881,10 @@ static void maybe_free_inode_rec(struct cache_tree *inode_cache,
 	}
 
 	if (S_ISREG(rec->imode) || S_ISLNK(rec->imode)) {
-		if (rec->found_csum_item && rec->nodatasum)
-			rec->errors |= I_ERR_ODD_CSUM_ITEM;
+		/*
+		 * A NODATASUM inode may reference a checksummed extent cloned
+		 * from a checksummed inode.  NODATASUM only affects new extents.
+		 */
 		if (rec->some_csum_missing && !rec->nodatasum)
 			rec->errors |= I_ERR_SOME_CSUM_MISSING;
 	}
@@ -1094,8 +1096,6 @@ skip_backrefs:
 		dst->found_dir_item = 1;
 	if (src->found_file_extent)
 		dst->found_file_extent = 1;
-	if (src->found_csum_item)
-		dst->found_csum_item = 1;
 	if (src->some_csum_missing)
 		dst->some_csum_missing = 1;
 	if (first_extent_gap(&dst->holes) > first_extent_gap(&src->holes)) {
@@ -1786,8 +1786,6 @@ static int process_file_extent(struct btrfs_root *root,
 		    (btrfs_file_extent_compression(eb, fi) ||
 		     btrfs_file_extent_other_encoding(eb, fi)))
 			rec->errors |= I_ERR_BAD_FILE_EXTENT;
-		if (compression && rec->nodatasum)
-			rec->errors |= I_ERR_BAD_FILE_EXTENT;
 		if (disk_bytenr > 0)
 			rec->found_size += num_bytes;
 		/*
@@ -1823,8 +1821,6 @@ static int process_file_extent(struct btrfs_root *root,
 		if (ret < 0)
 			return ret;
 		if (extent_type == BTRFS_FILE_EXTENT_REG) {
-			if (found > 0)
-				rec->found_csum_item = 1;
 			if (found < num_bytes)
 				rec->some_csum_missing = 1;
 			if (compression && found < num_bytes)

--- a/check/mode-lowmem.c
+++ b/check/mode-lowmem.c
@@ -2171,11 +2171,12 @@ static int check_file_extent(struct btrfs_root *root, struct btrfs_path *path,
 		search_len = disk_num_bytes;
 	}
 	ret = count_csum_range(search_start, search_len, &csum_found);
-	if (csum_found > 0 && nodatasum) {
-		err |= ODD_CSUM_ITEM;
-		error("root %llu EXTENT_DATA[%llu %llu] nodatasum shouldn't have datasum",
-		      root->objectid, fkey.objectid, fkey.offset);
-	} else if (extent_type == BTRFS_FILE_EXTENT_REG && !nodatasum &&
+	/*
+	 * NODATASUM controls whether new extents get checksums.  A checksummed
+	 * extent can still be referenced by a NODATASUM inode after reflinking
+	 * from a checksummed inode, so the presence of a checksum is valid here.
+	 */
+	if (extent_type == BTRFS_FILE_EXTENT_REG && !nodatasum &&
 		   !is_hole && (ret < 0 || csum_found < search_len)) {
 		err |= CSUM_ITEM_MISSING;
 		error("root %llu EXTENT_DATA[%llu %llu] csum missing, have: %llu, expected: %llu",
@@ -2196,9 +2197,8 @@ static int check_file_extent(struct btrfs_root *root, struct btrfs_path *path,
 	}
 
 	/*
-	 * Extra check for compressed extents:
-	 * Btrfs doesn't allow NODATASUM and compressed extent co-exist, thus
-	 * all compressed extents should have a checksum.
+	 * A compressed extent may be referenced by a NODATASUM inode after a
+	 * reflink, but the extent itself must still have a checksum.
 	 */
 	if (compressed && csum_found < search_len) {
 		error(
@@ -2206,12 +2206,6 @@ static int check_file_extent(struct btrfs_root *root, struct btrfs_path *path,
 		      root->objectid, fkey.objectid, fkey.offset, csum_found,
 		      search_len);
 		err |= CSUM_ITEM_MISSING;
-	}
-	if (compressed && nodatasum) {
-		error(
-"root %llu EXTENT_DATA[%llu %llu] is compressed, but inode flag doesn't allow it",
-		      root->objectid, fkey.objectid, fkey.offset);
-		err |= FILE_EXTENT_ERROR;
 	}
 
 	/* Check EXTENT_DATA hole */

--- a/check/mode-original.h
+++ b/check/mode-original.h
@@ -205,7 +205,6 @@ struct inode_record {
 	unsigned int found_inode_item:1;
 	unsigned int found_dir_item:1;
 	unsigned int found_file_extent:1;
-	unsigned int found_csum_item:1;
 	unsigned int some_csum_missing:1;
 	unsigned int nodatasum:1;
 	int errors;


### PR DESCRIPTION
Checksummed extents can be shared by checksummed and NODATASUM inodes
after reflinking from the former into the latter. This is supported by
the kernel series below.

Link: https://lore.kernel.org/linux-btrfs/20260712-reflink-into-nodatasum-v1-0-9f27ef836073@amutable.com/
Signed-off-by: Daan De Meyer <daan@amutable.com>
