### PR TITLE
Error handling fixes and cleanups

### DIFF
--- a/cmds/property.c
+++ b/cmds/property.c
@@ -156,11 +156,11 @@ static int prop_label(enum prop_object_type type,
 	int ret;
 
 	if (value) {
-		ret = set_label((char *) object, (char *) value);
+		ret = set_label(object, value);
 	} else {
 		char label[BTRFS_LABEL_SIZE];
 
-		ret = get_label((char *) object, label);
+		ret = get_label(object, label);
 		if (!ret)
 			pr_default("label=%s\n", label);
 	}

--- a/cmds/receive.c
+++ b/cmds/receive.c
@@ -1560,6 +1560,10 @@ static int do_receive(struct btrfs_receive *rctx, const char *tomnt,
 		if (bconf.verbose > BTRFS_BCONF_QUIET)
 			fprintf(stderr, "Chroot to %s\n", dest_dir_full_path);
 		rctx->root_path = strdup("/");
+		if (!rctx->root_path) {
+			ret = -ENOMEM;
+			goto out;
+		}
 		rctx->dest_dir_path = rctx->root_path;
 	} else {
 		/*

--- a/cmds/receive.c
+++ b/cmds/receive.c
@@ -699,7 +699,6 @@ static int process_write(const char *path, const void *data, u64 offset,
 	struct btrfs_receive *rctx = user;
 	char full_path[PATH_MAX];
 	u64 pos = 0;
-	int w;
 
 	ret = path_cat_out(full_path, rctx->full_subvol_path, path);
 	if (ret < 0) {
@@ -716,6 +715,8 @@ static int process_write(const char *path, const void *data, u64 offset,
 			path, offset, len);
 
 	while (pos < len) {
+		ssize_t w;
+
 		w = pwrite(rctx->write_fd, (char*)data + pos, len - pos,
 				offset + pos);
 		if (w == 0) {

--- a/cmds/receive.c
+++ b/cmds/receive.c
@@ -718,6 +718,11 @@ static int process_write(const char *path, const void *data, u64 offset,
 	while (pos < len) {
 		w = pwrite(rctx->write_fd, (char*)data + pos, len - pos,
 				offset + pos);
+		if (w == 0) {
+			ret = -EIO;
+			error("writing to %s failed (zero bytes written)", path);
+			goto out;
+		}
 		if (w < 0) {
 			ret = -errno;
 			error("writing to %s failed: %m", path);
@@ -1237,6 +1242,11 @@ static int decompress_and_write(struct btrfs_receive *rctx,
 
 		w = pwrite(rctx->write_fd, unencoded_data + unencoded_offset,
 			   unencoded_file_len - written, offset);
+		if (w == 0) {
+			ret = -EIO;
+			error("writing unencoded data failed (zero bytes written)");
+			goto out;
+		}
 		if (w < 0) {
 			ret = -errno;
 			error("writing unencoded data failed: %m");

--- a/cmds/subvolume-list.c
+++ b/cmds/subvolume-list.c
@@ -728,6 +728,8 @@ static int resolve_root(struct rb_root *rl, struct root_info *ri,
 			len += add_len + 1;
 		} else {
 			full_path = strdup(found->path);
+			if (!full_path)
+				return -ENOMEM;
 			len = add_len;
 		}
 		if (!ri->top_id)

--- a/cmds/subvolume.c
+++ b/cmds/subvolume.c
@@ -1808,9 +1808,8 @@ static int cmd_subvolume_sync(const struct cmd_struct *cmd, int argc, char **arg
 			const char *arg;
 
 			arg = argv[optind + i];
-			errno = 0;
-			id = strtoull(arg, NULL, 10);
-			if (errno) {
+			ret = parse_u64(arg, &id);
+			if (ret < 0) {
 				error("unrecognized subvolume id %s", arg);
 				ret = 1;
 				goto out;

--- a/cmds/subvolume.c
+++ b/cmds/subvolume.c
@@ -457,8 +457,18 @@ again:
 		goto out;
 	}
 	dupdname = strdup(cpath);
+	if (!dupdname) {
+		error_mem("duplicate path");
+		ret = -ENOMEM;
+		goto out;
+	}
 	dname = path_dirname(dupdname);
 	dupvname = strdup(cpath);
+	if (!dupvname) {
+		error_mem("duplicate path");
+		ret = -ENOMEM;
+		goto out;
+	}
 	vname = path_basename(dupvname);
 	free(cpath);
 
@@ -713,6 +723,10 @@ static int cmd_subvolume_snapshot(const struct cmd_struct *cmd, int argc, char *
 		const char *newname;
 
 		dupname = strdup(subvol);
+		if (!dupname) {
+			error_mem("duplicate subvolume");
+			goto out;
+		}
 		newname = path_basename(dupname);
 
 		dstdir = malloc(strlen(dst) + 1 + strlen(newname) + 1);
@@ -730,6 +744,10 @@ static int cmd_subvolume_snapshot(const struct cmd_struct *cmd, int argc, char *
 		free(dupname);
 	} else {
 		dstdir = strdup(dst);
+		if (!dstdir) {
+			error_mem(NULL);
+			goto out;
+		}
 	}
 
 	err = btrfs_util_subvolume_snapshot(subvol, dstdir, flags, NULL, inherit);
@@ -1621,6 +1639,11 @@ static int cmd_subvolume_show(const struct cmd_struct *cmd, int argc, char **arg
 	if (subvol.id == BTRFS_FS_TREE_OBJECTID) {
 		free(subvol_path);
 		subvol_path = strdup("/");
+		if (!subvol_path) {
+			error_mem(NULL);
+			ret = -ENOMEM;
+			goto out;
+		}
 		subvol_name = "<FS_TREE>";
 	} else {
 		subvol_name = path_basename(subvol_path);

--- a/cmds/subvolume.c
+++ b/cmds/subvolume.c
@@ -345,7 +345,7 @@ static int cmd_subvolume_delete(const struct cmd_struct *cmd, int argc, char **a
 	u8 fsid[BTRFS_FSID_SIZE];
 	u64 subvolid = 0;
 	char uuidbuf[BTRFS_UUID_UNPARSED_SIZE];
-	char full_subvolpath[BTRFS_SUBVOL_NAME_MAX];
+	char full_subvolpath[PATH_MAX];
 	struct seen_fsid *seen_fsid_hash[SEEN_FSID_HASH_SIZE] = { NULL, };
 	enum { COMMIT_AFTER = 1, COMMIT_EACH = 2 };
 	enum btrfs_util_error err;

--- a/cmds/subvolume.c
+++ b/cmds/subvolume.c
@@ -178,7 +178,7 @@ static int create_one_subvolume(const char *dst, struct btrfs_util_qgroup_inheri
 			} else if (ret <= 0) {
 				if (ret == 0)
 					ret = -EEXIST;
-				errno = ret ;
+				errno = -ret ;
 				error("failed to check directory %s before creation: %m", p);
 				goto out;
 			}

--- a/cmds/subvolume.c
+++ b/cmds/subvolume.c
@@ -665,7 +665,8 @@ static int cmd_subvolume_snapshot(const struct cmd_struct *cmd, int argc, char *
 {
 	char	*subvol, *dst;
 	int	res, retval;
-	char	*dstdir = NULL;
+	int ret;
+	char dest_dir[PATH_MAX];
 	enum btrfs_util_error err;
 	struct btrfs_util_qgroup_inherit *inherit = NULL;
 	int flags = 0;
@@ -729,28 +730,17 @@ static int cmd_subvolume_snapshot(const struct cmd_struct *cmd, int argc, char *
 		}
 		newname = path_basename(dupname);
 
-		dstdir = malloc(strlen(dst) + 1 + strlen(newname) + 1);
-		if (!dstdir) {
-			error_mem(NULL);
-			free(dupname);
-			goto out;
-		}
-
-		dstdir[0] = 0;
-		strcpy(dstdir, dst);
-		strcat(dstdir, "/");
-		strcat(dstdir, newname);
-
+		ret = path_cat_out(dest_dir, dst, newname);
 		free(dupname);
-	} else {
-		dstdir = strdup(dst);
-		if (!dstdir) {
-			error_mem(NULL);
+		if (ret < 0) {
+			error("path too long");
 			goto out;
 		}
+	} else {
+		strncpy_null(dest_dir, dst, PATH_MAX);
 	}
 
-	err = btrfs_util_subvolume_snapshot(subvol, dstdir, flags, NULL, inherit);
+	err = btrfs_util_subvolume_snapshot(subvol, dest_dir, flags, NULL, inherit);
 	if (err) {
 		error_btrfs_util(err);
 		goto out;
@@ -759,14 +749,11 @@ static int cmd_subvolume_snapshot(const struct cmd_struct *cmd, int argc, char *
 	retval = 0;	/* success */
 
 	if (flags & BTRFS_UTIL_CREATE_SNAPSHOT_READ_ONLY)
-		pr_default("Create readonly snapshot of '%s' in '%s'\n",
-			   subvol, dstdir);
+		pr_default("Create readonly snapshot of '%s' in '%s'\n", subvol, dest_dir);
 	else
-		pr_default("Create snapshot of '%s' in '%s'\n",
-			   subvol, dstdir);
+		pr_default("Create snapshot of '%s' in '%s'\n", subvol, dest_dir);
 
 out:
-	free(dstdir);
 	btrfs_util_qgroup_inherit_destroy(inherit);
 
 	return retval;

--- a/common/inject-error.c
+++ b/common/inject-error.c
@@ -33,6 +33,7 @@ static bool cookie_enabled(unsigned long cookie) {
 	if (inj == NULL || inj[0] == 0)
 		return false;
 
+	errno = 0;
 	envcookie = strtoul(inj, NULL, 0);
 	if (envcookie == cookie)
 		return true;

--- a/common/parse-utils.c
+++ b/common/parse-utils.c
@@ -52,6 +52,7 @@ int parse_u64(const char *str, u64 *result)
 	 */
 	if (str[0] == '-')
 		return -EINVAL;
+	errno = 0;
 	val = strtoull(str, &endptr, 10);
 	if (*endptr)
 		return -EINVAL;
@@ -89,6 +90,7 @@ int parse_range_u64(const char *range, u64 *start, u64 *end)
 		*end = (u64)-1;
 		skipped++;
 	} else {
+		errno = 0;
 		*end = strtoull(rest, &endptr, 10);
 		if (*endptr)
 			return 1;
@@ -97,6 +99,7 @@ int parse_range_u64(const char *range, u64 *start, u64 *end)
 		*start = 0;
 		skipped++;
 	} else {
+		errno = 0;
 		*start = strtoull(range, &endptr, 10);
 		if (*endptr != 0 && *endptr != '.')
 			return 1;
@@ -321,6 +324,7 @@ int parse_qgroupid(const char *str, u64 *qgroupid)
 	u64 level;
 	u64 id;
 
+	errno = 0;
 	level = strtoull(str, &end, 10);
 	if (str == end)
 		return -EINVAL;
@@ -328,6 +332,7 @@ int parse_qgroupid(const char *str, u64 *qgroupid)
 		return -EINVAL;
 	str = end + 1;
 	end = NULL;
+	errno = 0;
 	id = strtoull(str, &end, 10);
 	if (str == end)
 		return -EINVAL;

--- a/common/sysfs-utils.c
+++ b/common/sysfs-utils.c
@@ -168,12 +168,12 @@ int sysfs_write_file_u64(const char *name, u64 value)
 	return ret;
 }
 
-int sysfs_read_fsid_file_u64(int fd, const char *name, u64 *value)
+int sysfs_read_fsid_file_u64(int fs_fd, const char *name, u64 *value)
 {
-	int ret;
+	int ret, fd;
 	char str[32] = { 0 };
 
-	fd = sysfs_open_fsid_file(fd, name);
+	fd = sysfs_open_fsid_file(fs_fd, name);
 	if (fd < 0)
 		return fd;
 
@@ -189,12 +189,12 @@ out:
 	return ret;
 }
 
-int sysfs_write_fsid_file_u64(int fd, const char *name, u64 value)
+int sysfs_write_fsid_file_u64(int fs_fd, const char *name, u64 value)
 {
-	int ret;
+	int ret, fd;
 	char str[32] = { 0 };
 
-	fd = sysfs_open_fsid_file_rw(fd, name);
+	fd = sysfs_open_fsid_file_rw(fs_fd, name);
 	if (fd < 0)
 		return fd;
 
@@ -204,12 +204,12 @@ int sysfs_write_fsid_file_u64(int fd, const char *name, u64 value)
 	return ret;
 }
 
-int sysfs_read_fsid_file_clean_str(int fd, const char *name, char *buf, size_t size)
+int sysfs_read_fsid_file_clean_str(int fs_fd, const char *name, char *buf, size_t size)
 {
-	int ret;
+	int ret, fd;
 	size_t end;
 
-	fd = sysfs_open_fsid_file(fd, name);
+	fd = sysfs_open_fsid_file(fs_fd, name);
 	if (fd < 0)
 		return fd;
 

--- a/crypto/hash-speedtest.c
+++ b/crypto/hash-speedtest.c
@@ -257,6 +257,10 @@ int main(int argc, char **argv) {
 		case 'f':
 			free(filter);
 			filter = strdup(optarg);
+			if (!filter) {
+				error_mem("filter");
+				return 1;
+			}
 			printf("Use filter: %s\n", filter);
 			break;
 		case 't':

--- a/image/common.c
+++ b/image/common.c
@@ -218,12 +218,10 @@ int update_disk_super_on_device(struct btrfs_fs_info *info,
 
 	ret = pwrite(fp, &disk_super, BTRFS_SUPER_INFO_SIZE, BTRFS_SUPER_INFO_OFFSET);
 	if (ret != BTRFS_SUPER_INFO_SIZE) {
-		if (ret < 0) {
-			errno = ret;
+		if (ret < 0)
 			error("cannot write superblock: %m");
-		} else {
+		else
 			error("cannot write superblock");
-		}
 		ret = -EIO;
 		goto out;
 	}

--- a/mkfs/main.c
+++ b/mkfs/main.c
@@ -1634,6 +1634,10 @@ int BOX_MAIN(mkfs)(int argc, char **argv)
 					exit(1);
 				}
 				label = strdup(optarg);
+				if (!label) {
+					error_mem("option label");
+					exit(1);
+				}
 				break;
 			case 'm':
 				ret = parse_bg_profile(optarg, &metadata_profile);
@@ -1649,6 +1653,12 @@ int BOX_MAIN(mkfs)(int argc, char **argv)
 			case 'O': {
 				char *orig = strdup(optarg);
 				char *tmp = orig;
+
+				if (!orig) {
+					error_mem("option features");
+					ret = 1;
+					goto error;
+				}
 
 				tmp = btrfs_parse_fs_features(tmp, &features);
 				if (tmp) {
@@ -1669,6 +1679,12 @@ int BOX_MAIN(mkfs)(int argc, char **argv)
 			case 'R': {
 				char *orig = strdup(optarg);
 				char *tmp = orig;
+
+				if (!orig) {
+					error_mem("option runtime features");
+					ret = 1;
+					goto error;
+				}
 
 				warning("runtime features are deprecated, use -O, --features instead");
 				tmp = btrfs_parse_runtime_features(tmp,
@@ -1704,6 +1720,11 @@ int BOX_MAIN(mkfs)(int argc, char **argv)
 			case 'r':
 				free(source_dir);
 				source_dir = strdup(optarg);
+				if (!source_dir) {
+					error_mem("option source directory");
+					ret = 1;
+					goto error;
+				}
 				break;
 			case 'u':
 				ret = parse_subvolume(optarg, &subvols, &has_default_subvol);

--- a/tests/fssum.c
+++ b/tests/fssum.c
@@ -479,6 +479,10 @@ check_manifest(char *fn, char *m, char *c, int last_call)
 
 			/* final cs */
 			checksum = strdup(l);
+			if (!checksum) {
+				fprintf(stderr, "allocating checksum\n");
+				exit(1);
+			}
 			break;
 		}
 		if (rem_c == l) {
@@ -502,8 +506,20 @@ malformed:
 		} else if (cmp > 0) {
 			excess_file(fn);
 			prev_fn = strdup(l);
+			if (!prev_fn) {
+				fprintf(stderr, "memory allocation error\n");
+				exit(1);
+			}
 			prev_m = strdup(rem_m);
+			if (!prev_m) {
+				fprintf(stderr, "memory allocation error\n");
+				exit(1);
+			}
 			prev_c = strdup(rem_c); 
+			if (!prev_c) {
+				fprintf(stderr, "memory allocation error\n");
+				exit(1);
+			}
 			return;
 		}
 		missing_file(l);
@@ -836,6 +852,10 @@ main(int argc, char *argv[])
 			if (checksum)
 				free(checksum);
 			checksum = strdup(p);
+			if (!checksum) {
+				fprintf(stderr, "memory allocation error\n");
+				exit(1);
+			}
 		} else {
 			fprintf(stderr, "invalid input file format\n");
 			exit(-1);


### PR DESCRIPTION

- **btrfs-progs: handle strdup() failures**
- **btrfs-progs: don't reuse filesystem fd for sysfs files**
- **btrfs-progs: reset errno before strtoull() when parsing numbers**
- **btrfs-progs: use parse_u64() in cmd_subvolume_sync()**
- **btrfs-progs: simplify reading read partition size in device_get_partition_size_sysfs()**
- **btrfs-progs: use path API to build subvolume paths**
- **btrfs-progs: use full size path buffer in cmd_subvolume_delete()**
- **btrfs-progs: fix assigning negative errno**
- **btrfs-progs: receive: handle writes of 0 bytes**
- **btrfs-progs: receive: use correct type for pwrite in process_write()**
- **btrfs-progs: drop type casts from set/get_label calls**
