### PR TITLE
btrfs-progs: fix-data-checksum: fix the error mirror bitmap allocation and indexing

### DIFF
--- a/cmds/rescue-fix-data-checksum.c
+++ b/cmds/rescue-fix-data-checksum.c
@@ -85,7 +85,7 @@ static int add_corrupted_block(struct btrfs_fs_info *fs_info, u64 logical,
 	/* The last entry is the same, just set update the error mirror bitmap. */
 	if (last->logical == logical) {
 		UASSERT(last->error_mirror_bitmap);
-		set_bit(mirror, last->error_mirror_bitmap);
+		set_bit(mirror - 1, last->error_mirror_bitmap);
 		return 0;
 	}
 add:

--- a/cmds/rescue-fix-data-checksum.c
+++ b/cmds/rescue-fix-data-checksum.c
@@ -16,6 +16,7 @@
 
 #include "kerncompat.h"
 #include <ctype.h>
+#include "kernel-lib/bitmap.h"
 #include "kernel-shared/disk-io.h"
 #include "kernel-shared/ctree.h"
 #include "kernel-shared/volumes.h"
@@ -91,7 +92,7 @@ add:
 	last = calloc(1, sizeof(*last));
 	if (!last)
 		return -ENOMEM;
-	last->error_mirror_bitmap = calloc(1, BITS_TO_LONGS(num_mirrors));
+	last->error_mirror_bitmap = bitmap_zalloc(num_mirrors);
 	if (!last->error_mirror_bitmap) {
 		free(last);
 		return -ENOMEM;
@@ -456,7 +457,7 @@ static void free_corrupted_blocks(void)
 
 		entry = list_entry(corrupted_blocks.next, struct corrupted_block, list);
 		list_del_init(&entry->list);
-		free(entry->error_mirror_bitmap);
+		bitmap_free(entry->error_mirror_bitmap);
 		free(entry);
 	}
 }


### PR DESCRIPTION
Two independent bugs in the error mirror bitmap of
"btrfs rescue fix-data-checksum", both in add_corrupted_block():

1. The allocation passes BITS_TO_LONGS() as the byte size to calloc(), so
   only one byte is allocated while set_bit() accesses it in unsigned long
   units. Shows up as a heap buffer overflow under ASAN.
2. The path updating an already recorded block sets bit @mirror instead of
   @mirror - 1, so the second and following corrupted mirrors of a block
   are misreported or dropped from the report.

Both hit in the default readonly mode. Details in the individual commits.

Tested on a DUP filesystem with checksum mismatches injected into one or
both mirrors, in readonly, interactive and -m modes, with an ASAN build.