### PR TITLE
btrfs-progs: docs: add a note about RW degraded mount

### DIFF
--- a/Documentation/ch-mount-options.rst
+++ b/Documentation/ch-mount-options.rst
@@ -180,6 +180,14 @@ degraded
         then the constraint of single/data is not satisfied and the filesystem
         cannot be mounted.
 
+	.. note::
+		During a degraded mount, if BTRFS is going to allocate a new chunk,
+		and the existing devices can not meet the requirement for the
+		current profile, BTRFS will fall back to other profiles like SINGLE.
+
+		It is recommended to check and balance chunks with unwanted profiles,
+		after an RW degraded mount.
+
 .. duplabel:: mount-option-device
 
 device=<devicepath>


### PR DESCRIPTION
When a new chunk is allocated during an RW degraded mount, btrfs can allocate new chunks with other profiles, like SINGLE, if the current devices can no longer support the original profile.

This can cause unexpected chunk profiles, and the end user is recommended to balance them out if they want to maintain the current allocation profile.