### PR TITLE
Set creation/change time (otime/ctime) for offline-created subvolumes and `convert`d root subvolume

### DIFF
--- a/common/root-tree-utils.c
+++ b/common/root-tree-utils.c
@@ -15,6 +15,7 @@
  */
 
 #include "kerncompat.h"
+#include <string.h>
 #include <time.h>
 #include <uuid/uuid.h>
 #include "kernel-shared/disk-io.h"
@@ -101,6 +102,16 @@ int btrfs_make_subvolume(struct btrfs_trans_handle *trans, u64 objectid,
 	ret = btrfs_make_root_dir(trans, root, BTRFS_FIRST_FREE_OBJECTID);
 	if (ret < 0)
 		goto error;
+
+	if (objectid != BTRFS_DATA_RELOC_TREE_OBJECTID) {
+		time_t now = time(NULL);
+		uuid_t uuid;
+
+		uuid_generate(uuid);
+		memcpy(root->root_item.uuid, uuid, BTRFS_UUID_SIZE);
+		btrfs_set_stack_timespec_sec(&root->root_item.otime, now);
+		btrfs_set_stack_timespec_sec(&root->root_item.ctime, now);
+	}
 
 	btrfs_set_stack_inode_flags(&root->root_item.inode,
 				    BTRFS_INODE_ROOT_ITEM_INIT);

--- a/convert/common.c
+++ b/convert/common.c
@@ -20,6 +20,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <uuid/uuid.h>
 #include "kernel-lib/sizes.h"
 #include "kernel-shared/ctree.h"
@@ -232,6 +233,18 @@ static void insert_temp_root_item(struct extent_buffer *buf,
 	btrfs_set_stack_inode_nlink(inode_item, 1);
 	btrfs_set_stack_inode_nbytes(inode_item, cfg->nodesize);
 	btrfs_set_stack_inode_mode(inode_item, S_IFDIR | 0755);
+
+	if (objectid == BTRFS_FS_TREE_OBJECTID) {
+		time_t now = time(NULL);
+		uuid_t uuid;
+
+		uuid_generate(uuid);
+		memcpy(root_item.uuid, uuid, BTRFS_UUID_SIZE);
+		btrfs_set_stack_timespec_sec(&root_item.otime, now);
+		btrfs_set_stack_timespec_sec(&root_item.ctime, now);
+		btrfs_set_stack_inode_flags(inode_item, BTRFS_INODE_ROOT_ITEM_INIT);
+	}
+
 	btrfs_set_root_refs(&root_item, 1);
 	btrfs_set_root_used(&root_item, cfg->nodesize);
 	btrfs_set_root_generation(&root_item, 1);


### PR DESCRIPTION
Fix `subvol->otime` and `subvol->ctime` not being set on:
- the root subvolume of a `btrfs-convert`d filesystem
- subvolumes created by `mkfs.btrfs` using `--rootdir` and `--subvol` options
- (less important) the `ext2_saved` subvolume of a `btrfs-convert`'d filesystem

Thanks