### PR TITLE
libbtrfsutil: don't leave the subvolume iterator pointing at an unfilled search buffer

### DIFF
--- a/libbtrfsutil/subvolume.c
+++ b/libbtrfsutil/subvolume.c
@@ -1501,8 +1501,18 @@ static enum btrfs_util_error subvolume_iterator_next_tree_search(struct btrfs_ut
 			} else {
 				top->search.key.nr_items = 4096;
 				ret = ioctl(iter->fd, BTRFS_IOC_TREE_SEARCH, &top->search);
-				if (ret == -1)
+				if (ret == -1) {
+					/*
+					 * nr_items was set above but the ioctl
+					 * left buf untouched. Clear it so that
+					 * a caller which keeps iterating does
+					 * not walk the stale buffer.
+					 */
+					top->search.key.nr_items = 0;
+					top->items_pos = 0;
+					top->buf_off = 0;
 					return BTRFS_UTIL_ERROR_SEARCH_FAILED;
+				}
 				top->items_pos = 0;
 				top->buf_off = 0;
 


### PR DESCRIPTION
Fixes the out-of-bounds read reported in #1158.

`subvolume_iterator_next_tree_search()` sets `nr_items` to 4096 before `BTRFS_IOC_TREE_SEARCH` and returns `BTRFS_UTIL_ERROR_SEARCH_FAILED` without restoring it when the ioctl fails. `items_pos` and `buf_off` are left at 0, so the next call to `btrfs_util_subvolume_iterator_next()` takes the `items_pos < nr_items` branch and parses search headers out of a buffer the failed ioctl never filled. With 4096 phantom items the walk ends roughly 128 KB past a 3992 byte buffer, which either segfaults or spins.

An unprivileged caller reaches this without doing anything unusual: `use_tree_search` is true whenever `top != 0`, so the iterator is created successfully and the first ioctl then fails with EPERM. That is how btrfs-assistant crashed on `--help`.

The patch resets the entry on the error path, so the buffer is never parsed before an ioctl has filled it.

Checked on btrfs-progs devel, kernel 7.2.0, one single-device filesystem at /, using the reproducer attached to #1158 and a bounded variant of it:

| | packaged 7.1 | this branch |
|---|---|---|
| ordinary user | SIGSEGV (exit 139) | `create -> 0`, then `12 (Could not search B-tree)` on every call, exit 0 |
| root | `@`, `@/var/lib/portables`, `@/var/lib/machines`, `@/.snapshots`, `@/.snapshots/950/snapshot` | identical, byte for byte |

The success path is untouched, only the error path changes.

I also have a follow-up patch that remembers the failure in the iterator so a caller which loops until `STOP_ITERATION` stops re-issuing the ioctl that just failed. It does not save such a caller from looping, so I left it out here; happy to send it if you want it.
