### PR TITLE
btrfs-progs: sb-mod: use per-type digest size for superblock csum

### DIFF
--- a/btrfs-sb-mod.c
+++ b/btrfs-sb-mod.c
@@ -30,7 +30,6 @@
 
 #define BLOCKSIZE (4096)
 static char buf[BLOCKSIZE];
-static int csum_size;
 
 static int check_csum_superblock(void *sb)
 {
@@ -40,7 +39,7 @@ static int check_csum_superblock(void *sb)
 	btrfs_csum_data(csum_type, (unsigned char *)sb + BTRFS_CSUM_SIZE,
 			result, BTRFS_SUPER_INFO_SIZE - BTRFS_CSUM_SIZE);
 
-	return (memcmp(sb, result, csum_size) == 0);
+	return (memcmp(sb, result, btrfs_csum_type_size(csum_type)) == 0);
 }
 
 static void update_block_csum(void *block)
@@ -54,7 +53,7 @@ static void update_block_csum(void *block)
 
 	memset(block, 0, BTRFS_CSUM_SIZE);
 	hdr = (struct btrfs_header *)block;
-	memcpy(&hdr->csum, result, csum_size);
+	memcpy(&hdr->csum, result, btrfs_csum_type_size(csum_type));
 }
 
 static u64 arg_strtou64(const char *str)
@@ -159,7 +158,7 @@ struct sb_field {
 			printf("SET: "#fname" "f_dec" (0x"f_hex")\n", \
 			(f_type)*val, (f_type)*val);				\
 			sb->fname = cpu_to_le##bits(*val);			\
-		} else {							\
+		} else {						\
 			*val = le##bits##_to_cpu(sb->fname);			\
 			printf("GET: "#fname" "f_dec" (0x"f_hex")\n", 	\
 			(f_type)*val, (f_type)*val);			\
@@ -374,7 +373,6 @@ int main(int argc, char **argv)
 	}
 
 	/* verify superblock */
-	csum_size = btrfs_csum_type_size(BTRFS_CSUM_TYPE_CRC32);
 	off = BTRFS_SUPER_INFO_OFFSET;
 
 	ret = pread(fd, buf, BLOCKSIZE, off);

--- a/btrfs-sb-mod.c
+++ b/btrfs-sb-mod.c
@@ -158,7 +158,7 @@ struct sb_field {
 			printf("SET: "#fname" "f_dec" (0x"f_hex")\n", \
 			(f_type)*val, (f_type)*val);				\
 			sb->fname = cpu_to_le##bits(*val);			\
-		} else {						\
+		} else {							\
 			*val = le##bits##_to_cpu(sb->fname);			\
 			printf("GET: "#fname" "f_dec" (0x"f_hex")\n", 	\
 			(f_type)*val, (f_type)*val);			\


### PR DESCRIPTION
## Summary

`btrfs-sb-mod` hardcodes the superblock checksum length to the CRC32C
digest size instead of using the digest size of the filesystem's actual
checksum type:

- `main()` does `csum_size = btrfs_csum_type_size(BTRFS_CSUM_TYPE_CRC32);`
  while every read/write path derives `csum_type` from
  `btrfs_super_csum_type(sb)`.
- `check_csum_superblock()` then compares only the first
  `csum_size` (= 4) bytes.
- `update_block_csum()` zeroes the whole 32-byte csum field and writes
  back only the first 4 bytes of the digest.

## Affected algorithms

| csum type | digest size | affected |
|---|---|---|
| crc32c | 4 | no (only case where 4 is correct) |
| xxhash64 | 8 | yes — stored csum truncated, e.g. `0x7cbc602b00000000` |
| sha256 | 32 | yes |
| blake2b | 32 | yes |

So three of the four supported algorithms produce `[DON'T MATCH]`
superblocks after any `btrfs-sb-mod` write, and reads mis-validate.

## Fix

Replace both uses of the global with
`btrfs_csum_type_size(csum_type)` (same helper the rest of btrfs-progs
uses) and drop the now-unused global. This fixes #1160.

## Testing

Hit during a real recovery of a 5 TB btrbk target (xxhash64): with the
patched binary,

```
$ btrfs-sb-mod img generation '=26549' root '=761057165312'
...
Update csum
$ btrfs inspect-internal dump-super img | grep csum
csum            0x7cbc602bf714f3a8 [match]
```

vs unpatched: `csum 0x7cbc602b00000000 [DON'T MATCH]`. The repaired
image mounts read-only and the kernel accepts the superblock.

Fixes #1160