### PR TITLE
btrfs-progs: send-stream: read the stream through a 64 KiB buffer

### DIFF
--- a/common/send-stream.c
+++ b/common/send-stream.c
@@ -40,10 +40,24 @@ struct btrfs_send_attribute {
 	char *data;
 };
 
+/*
+ * The stream is read through a buffer of this size. Without it, every
+ * command costs two read() calls, one for the header and one for the
+ * payload, which on a metadata-heavy stream is one system call per few
+ * bytes. 64 KiB is the capacity of a pipe, the usual source; a larger
+ * buffer cannot get more per call, and payloads bigger than the buffer are
+ * read straight into the command buffer.
+ */
+#define BTRFS_SEND_STREAM_READ_BUF	SZ_64K
+
 struct btrfs_send_stream {
 	char *read_buf;
 	size_t read_buf_size;
 	int fd;
+	char *stream_buf;
+	size_t stream_buf_size;
+	size_t stream_buf_pos;
+	size_t stream_buf_len;
 
 	int cmd;
 	struct btrfs_send_attribute cmd_attrs[__BTRFS_SEND_A_MAX + 1];
@@ -73,8 +87,26 @@ static int read_buf(struct btrfs_send_stream *sctx, char *buf, size_t len)
 
 	while (pos < len) {
 		ssize_t rbytes;
+		size_t avail = sctx->stream_buf_len - sctx->stream_buf_pos;
 
-		rbytes = read(sctx->fd, buf + pos, len - pos);
+		if (avail > 0) {
+			size_t n = len - pos < avail ? len - pos : avail;
+
+			memcpy(buf + pos, sctx->stream_buf + sctx->stream_buf_pos, n);
+			sctx->stream_buf_pos += n;
+			pos += n;
+			continue;
+		}
+		if (len - pos >= sctx->stream_buf_size) {
+			rbytes = read(sctx->fd, buf + pos, len - pos);
+		} else {
+			rbytes = read(sctx->fd, sctx->stream_buf, sctx->stream_buf_size);
+			if (rbytes > 0) {
+				sctx->stream_buf_pos = 0;
+				sctx->stream_buf_len = rbytes;
+				continue;
+			}
+		}
 		if (rbytes < 0) {
 			if (errno == EINTR)
 				continue;
@@ -619,6 +651,15 @@ int btrfs_read_and_process_send_stream(int fd,
 	sctx.ops = ops;
 	sctx.user = user;
 	sctx.stream_pos = 0;
+	sctx.stream_buf_pos = 0;
+	sctx.stream_buf_len = 0;
+	sctx.stream_buf_size = BTRFS_SEND_STREAM_READ_BUF;
+	sctx.stream_buf = malloc(sctx.stream_buf_size);
+	if (!sctx.stream_buf) {
+		ret = -ENOMEM;
+		error_mem("send stream buffer");
+		goto out;
+	}
 
 	ret = read_buf(&sctx, (char*)&hdr, sizeof(hdr));
 	if (ret < 0)
@@ -666,6 +707,7 @@ int btrfs_read_and_process_send_stream(int fd,
 	free(sctx.read_buf);
 
 out:
+	free(sctx.stream_buf);
 	if (last_err && !ret)
 		ret = last_err;
 

--- a/tests/misc-tests/073-receive-stream-chunks/test.sh
+++ b/tests/misc-tests/073-receive-stream-chunks/test.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# The stream reader must produce the same tree however the bytes arrive:
+# from a file, through a pipe in 7-byte pieces (every header and payload
+# spans several reads), and through a pipe in pieces larger than its buffer.
+# A truncated stream must fail rather than pass as a shorter tree. The tree
+# has payloads on both sides of the reader's buffer size: small inline files
+# and multi-extent files with incompressible data sent with --compressed-data.
+
+source "$TEST_TOP/common" || exit
+
+check_prereq mkfs.btrfs
+check_prereq btrfs
+check_prereq fssum
+check_global_prereq dd
+check_global_prereq head
+
+setup_root_helper
+prepare_test_dev
+
+FSSUM_PROG="$INTERNAL_BIN/fssum"
+here=$(pwd)
+src="$TEST_MNT/src"
+
+run_check_mkfs_test_dev
+run_check_mount_test_dev
+run_check $SUDO_HELPER "$TOP/btrfs" subvolume create "$src"
+run_check $SUDO_HELPER mkdir -p "$src/dir/sub"
+run_check $SUDO_HELPER dd if=/dev/zero of="$src/dir/small" bs=1K count=3 status=none
+run_check $SUDO_HELPER dd if=/dev/zero of="$src/dir/sub/medium" bs=64K count=3 status=none
+run_check $SUDO_HELPER dd if=/dev/zero of="$src/dir/sub/large" bs=1M count=3 status=none
+run_check $SUDO_HELPER dd if=/dev/urandom of="$src/dir/random" bs=256K count=2 status=none
+run_check $SUDO_HELPER touch "$src/dir/empty"
+run_check $SUDO_HELPER ln -s sub/medium "$src/dir/link"
+run_check $SUDO_HELPER "$TOP/btrfs" subvolume snapshot -r "$src" "$TEST_MNT/snap"
+run_check $FSSUM_PROG -A -f -w "$here/snap.fssum" "$TEST_MNT/snap"
+
+_mktemp_local full.stream
+run_check $SUDO_HELPER "$TOP/btrfs" send -q --compressed-data -f "$here/full.stream" "$TEST_MNT/snap"
+
+receive_and_verify() {
+	local dest="$TEST_MNT/$1"
+
+	run_check $SUDO_HELPER mkdir "$dest"
+	shift
+	run_check $SUDO_HELPER bash -c "$* | '$TOP/btrfs' receive -q '$dest'"
+	run_check $FSSUM_PROG -r "$here/snap.fssum" "$dest/snap"
+}
+
+receive_and_verify file "cat '$here/full.stream'"
+receive_and_verify tiny-pieces "dd if='$here/full.stream' bs=7 status=none"
+receive_and_verify big-pieces "dd if='$here/full.stream' bs=1M status=none"
+
+_mktemp_local trunc.stream
+run_check bash -c "head -c \$(( \$(stat -c %s '$here/full.stream') * 2 / 3 )) '$here/full.stream' > '$here/trunc.stream'"
+run_check $SUDO_HELPER mkdir "$TEST_MNT/truncated"
+run_mustfail "truncated stream accepted" \
+	$SUDO_HELPER "$TOP/btrfs" receive -q -f "$here/trunc.stream" "$TEST_MNT/truncated"
+
+run_check_umount_test_dev
+rm -f -- "$here/snap.fssum" "$here/full.stream" "$here/trunc.stream"


### PR DESCRIPTION
## Description

`btrfs receive` reads its stream with one `read()` per command header and another per payload
(`read_buf()` in `common/send-stream.c`). On a metadata-heavy stream that is two system calls per
few bytes: a 3.3 GB `btrfs send --compressed-data` stream of an Omarchy root (191k files, 15k
directories, 53k symlinks; 1.5 M commands, 85% of them 256 bytes or smaller) takes 2.9 M reads.

This adds a 64 KiB read buffer. Payloads larger than the buffer are read directly into the
command buffer as before. 64 KiB matches the capacity of a pipe, the usual source of the stream.
Sizes from 2 KiB to 4 MiB were measured: 64 KiB and above perform the same, 8 KiB and below are
slower. The same stream now takes 58k reads instead of 2.9 M.

Behaviour is unchanged: EOF and short-read handling are the same, and `stream_pos` still counts
consumed bytes for error reporting.

## Measurements

Same stream received onto a freshly made btrfs, page-cached source, three runs each (average
shown), identical resulting tree (fssum over metadata, contents and xattrs).

**Target on LUKS2 (dm-crypt, default 512-byte sectors)**

| machine | stock | buffered | faster |
|---|---:|---:|---:|
| AMD Ryzen 9 9950X (16 cores), NVMe | 5.81 s | 5.62 s | 3.3% |
| ThinkPad X200 (Core 2 Duo P8400, SATA SSD) | 95.8 s | 92.8 s | 3.1% |

**Target on LUKS2 (dm-crypt, override with 4 KiB sectors)**

| machine | stock | buffered | faster |
|---|---:|---:|---:|
| AMD Ryzen 9 9950X (16 cores), NVMe | 5.83 s | 5.68 s | 2.5% |
| ThinkPad X200 (Core 2 Duo P8400, SATA SSD) | 94.2 s | 91.5 s | 2.9% |

**Target on plain btrfs**

| machine | stock | buffered | faster |
|---|---:|---:|---:|
| AMD Ryzen 9 9950X (16 cores), NVMe | 5.79 s | 5.61 s | 3.1% |
| ThinkPad X200 (Core 2 Duo P8400, SATA SSD) | 72.4 s | 68.2 s | 5.8% |

## Test

`tests/misc-tests/073-receive-stream-chunks`: the same stream received from a file, through a
pipe in 7-byte pieces (every header and payload spans several reads) and in 1 MiB pieces, each
checked with fssum; a truncated stream must be refused. Passes on this branch and on unmodified
devel (it tests the reader's contract, not this change).

## Notes

Part of a larger receive speed-up (create inodes under their final name, skip no-op chowns, keep
the created descriptor) measured at 6.0 s -> 3.6 s on the same stream; those are separate,
larger changes and will follow on their own if this one is welcome.

## Disclaimer

This change, its test and the measurements below were produced with the help of an AI coding
assistant (Claude, listed as co-author in the commits). The code has been read and the results
reproduced by me; the resulting tree was checked against stock `btrfs receive` with fssum
(metadata, contents, xattrs) on every run. Please review it as you would any other contribution.
